### PR TITLE
docs: add comprehensive CRD documentation from kagent PR #335

### DIFF
--- a/src/app/docs/concepts/crd/agent.mdx
+++ b/src/app/docs/concepts/crd/agent.mdx
@@ -1,0 +1,100 @@
+---
+title: "Agent CRD"
+description: "Learn about the Agent CRD and how to use it to define individual AI agents."
+---
+
+# Agent CRD
+
+The Agent CRD defines individual AI agents in KAgent. Each agent represents a single AI entity with its own configuration, capabilities, and behavior.
+
+## Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Agent
+metadata:
+  name: string
+  namespace: string
+spec:
+  description: string
+  model: string
+  systemPrompt: string
+  tools: []
+  memory: string
+  maxTokens: integer
+  temperature: number
+  stopSequences: []
+  metadata: object
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata.name` | string | Yes | Name of the agent |
+| `metadata.namespace` | string | Yes | Kubernetes namespace |
+| `spec.description` | string | No | Description of the agent's purpose |
+| `spec.model` | string | Yes | Name of the LLM model to use |
+| `spec.systemPrompt` | string | Yes | System prompt that defines agent behavior |
+| `spec.tools` | array | No | List of tools the agent can use |
+| `spec.memory` | string | No | Reference to a Memory CRD |
+| `spec.maxTokens` | integer | No | Maximum tokens for model responses |
+| `spec.temperature` | number | No | Model temperature (0.0 to 1.0) |
+| `spec.stopSequences` | array | No | Sequences that stop model generation |
+| `spec.metadata` | object | No | Additional metadata for the agent |
+
+## Example
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Agent
+metadata:
+  name: research-assistant
+  namespace: kagent
+spec:
+  description: "AI research assistant for technical documentation"
+  model: "gpt-4"
+  systemPrompt: |
+    You are a research assistant specialized in technical documentation.
+    Your task is to help users find and understand technical information.
+  tools:
+    - name: web-search
+    - name: code-search
+  memory: "research-memory"
+  maxTokens: 2000
+  temperature: 0.7
+  metadata:
+    category: "research"
+    version: "1.0.0"
+```
+
+## Usage
+
+1. Create a namespace for your agents:
+   ```bash
+   kubectl create namespace kagent
+   ```
+
+2. Apply the agent manifest:
+   ```bash
+   kubectl apply -f agent.yaml
+   ```
+
+3. Verify the agent:
+   ```bash
+   kubectl get agents -n kagent
+   ```
+
+## Best Practices
+
+1. Use descriptive names for your agents
+2. Keep system prompts focused and specific
+3. Configure appropriate memory settings
+4. Monitor token usage and costs
+5. Use namespaces to organize agents
+
+## Related Resources
+
+- [Team CRD](./team) - Group agents into teams
+- [Memory CRD](./memory) - Configure agent memory
+- [ModelConfig CRD](./model-config) - Define model configurations 

--- a/src/app/docs/concepts/crd/memory.mdx
+++ b/src/app/docs/concepts/crd/memory.mdx
@@ -1,0 +1,93 @@
+---
+title: "Memory CRD"
+description: "Learn about the Memory CRD and how to use it to configure agent memory storage and retrieval."
+---
+
+# Memory CRD
+
+The Memory CRD configures how agents store and retrieve information. It defines the storage backend, retention policies, and memory access patterns.
+
+## Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Memory
+metadata:
+  name: string
+  namespace: string
+spec:
+  type: string
+  storage: object
+  retention: object
+  access: object
+  metadata: object
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata.name` | string | Yes | Name of the memory configuration |
+| `metadata.namespace` | string | Yes | Kubernetes namespace |
+| `spec.type` | string | Yes | Memory type (e.g., "vector", "key-value") |
+| `spec.storage` | object | Yes | Storage configuration |
+| `spec.retention` | object | No | Memory retention settings |
+| `spec.access` | object | No | Memory access patterns |
+| `spec.metadata` | object | No | Additional memory metadata |
+
+## Example
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Memory
+metadata:
+  name: research-memory
+  namespace: kagent
+spec:
+  type: "vector"
+  storage:
+    backend: "redis"
+    connection:
+      host: "redis-master"
+      port: 6379
+  retention:
+    maxSize: "1GB"
+    ttl: "7d"
+  access:
+    mode: "read-write"
+    maxConcurrent: 10
+  metadata:
+    category: "research"
+    version: "1.0.0"
+```
+
+## Usage
+
+1. Create a namespace for your memory configurations:
+   ```bash
+   kubectl create namespace kagent
+   ```
+
+2. Apply the memory manifest:
+   ```bash
+   kubectl apply -f memory.yaml
+   ```
+
+3. Verify the memory configuration:
+   ```bash
+   kubectl get memories -n kagent
+   ```
+
+## Best Practices
+
+1. Choose appropriate storage backends
+2. Configure retention policies
+3. Set up access patterns
+4. Monitor memory usage
+5. Use namespaces for organization
+
+## Related Resources
+
+- [Agent CRD](./agent) - Configure agent memory
+- [Team CRD](./team) - Share memory across teams
+- [ModelConfig CRD](./model-config) - Define model configurations 

--- a/src/app/docs/concepts/crd/model-config.mdx
+++ b/src/app/docs/concepts/crd/model-config.mdx
@@ -1,0 +1,95 @@
+---
+title: "ModelConfig CRD"
+description: "Learn about the ModelConfig CRD and how to use it to define language model configurations."
+---
+
+# ModelConfig CRD
+
+The ModelConfig CRD defines configurations for language models used by agents. It specifies model parameters, API settings, and usage limits.
+
+## Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ModelConfig
+metadata:
+  name: string
+  namespace: string
+spec:
+  provider: string
+  model: string
+  api: object
+  parameters: object
+  limits: object
+  metadata: object
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata.name` | string | Yes | Name of the model configuration |
+| `metadata.namespace` | string | Yes | Kubernetes namespace |
+| `spec.provider` | string | Yes | Model provider (e.g., "openai", "anthropic") |
+| `spec.model` | string | Yes | Model name/identifier |
+| `spec.api` | object | Yes | API configuration |
+| `spec.parameters` | object | No | Model parameters |
+| `spec.limits` | object | No | Usage limits |
+| `spec.metadata` | object | No | Additional model metadata |
+
+## Example
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ModelConfig
+metadata:
+  name: gpt4-config
+  namespace: kagent
+spec:
+  provider: "openai"
+  model: "gpt-4"
+  api:
+    endpoint: "https://api.openai.com/v1"
+    keySecret: "openai-api-key"
+  parameters:
+    temperature: 0.7
+    maxTokens: 2000
+    topP: 1.0
+  limits:
+    requestsPerMinute: 60
+    tokensPerMinute: 40000
+  metadata:
+    category: "research"
+    version: "1.0.0"
+```
+
+## Usage
+
+1. Create a namespace for your model configurations:
+   ```bash
+   kubectl create namespace kagent
+   ```
+
+2. Apply the model configuration:
+   ```bash
+   kubectl apply -f model-config.yaml
+   ```
+
+3. Verify the configuration:
+   ```bash
+   kubectl get modelconfigs -n kagent
+   ```
+
+## Best Practices
+
+1. Use appropriate model providers
+2. Configure API settings securely
+3. Set reasonable usage limits
+4. Monitor model performance
+5. Use namespaces for organization
+
+## Related Resources
+
+- [Agent CRD](./agent) - Use model configurations
+- [Team CRD](./team) - Share model configurations
+- [Memory CRD](./memory) - Configure model memory 

--- a/src/app/docs/concepts/crd/team.mdx
+++ b/src/app/docs/concepts/crd/team.mdx
@@ -1,0 +1,90 @@
+---
+title: "Team CRD"
+description: "Learn about the Team CRD and how to use it to group agents into teams."
+---
+
+# Team CRD
+
+The Team CRD allows you to group multiple agents into teams for collaborative tasks. Teams can share resources, coordinate actions, and maintain consistent communication patterns.
+
+## Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Team
+metadata:
+  name: string
+  namespace: string
+spec:
+  description: string
+  agents: []
+  coordinator: string
+  communication: object
+  metadata: object
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata.name` | string | Yes | Name of the team |
+| `metadata.namespace` | string | Yes | Kubernetes namespace |
+| `spec.description` | string | No | Description of the team's purpose |
+| `spec.agents` | array | Yes | List of agent references |
+| `spec.coordinator` | string | Yes | Name of the coordinating agent |
+| `spec.communication` | object | No | Team communication settings |
+| `spec.metadata` | object | No | Additional team metadata |
+
+## Example
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Team
+metadata:
+  name: research-team
+  namespace: kagent
+spec:
+  description: "Team of research assistants for technical documentation"
+  agents:
+    - name: research-assistant
+    - name: code-analyzer
+    - name: documentation-writer
+  coordinator: research-assistant
+  communication:
+    mode: "hierarchical"
+    maxConcurrentTasks: 3
+  metadata:
+    category: "research"
+    version: "1.0.0"
+```
+
+## Usage
+
+1. Create a namespace for your teams:
+   ```bash
+   kubectl create namespace kagent
+   ```
+
+2. Apply the team manifest:
+   ```bash
+   kubectl apply -f team.yaml
+   ```
+
+3. Verify the team:
+   ```bash
+   kubectl get teams -n kagent
+   ```
+
+## Best Practices
+
+1. Keep teams focused on specific domains
+2. Choose an appropriate coordinator agent
+3. Configure communication patterns
+4. Monitor team performance
+5. Use namespaces for team organization
+
+## Related Resources
+
+- [Agent CRD](./agent) - Define individual agents
+- [Memory CRD](./memory) - Configure team memory
+- [ModelConfig CRD](./model-config) - Define model configurations 

--- a/src/app/docs/concepts/crd/tool-server.mdx
+++ b/src/app/docs/concepts/crd/tool-server.mdx
@@ -1,0 +1,99 @@
+---
+title: "ToolServer CRD"
+description: "Learn about the ToolServer CRD and how to use it to define tool server configurations."
+---
+
+# ToolServer CRD
+
+The ToolServer CRD defines configurations for tool servers that provide additional capabilities to agents. It specifies server endpoints, authentication, and available tools.
+
+## Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ToolServer
+metadata:
+  name: string
+  namespace: string
+spec:
+  endpoint: string
+  auth: object
+  tools: []
+  limits: object
+  metadata: object
+```
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `metadata.name` | string | Yes | Name of the tool server |
+| `metadata.namespace` | string | Yes | Kubernetes namespace |
+| `spec.endpoint` | string | Yes | Server endpoint URL |
+| `spec.auth` | object | Yes | Authentication configuration |
+| `spec.tools` | array | Yes | List of available tools |
+| `spec.limits` | object | No | Usage limits |
+| `spec.metadata` | object | No | Additional server metadata |
+
+## Example
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ToolServer
+metadata:
+  name: research-tools
+  namespace: kagent
+spec:
+  endpoint: "https://tools.example.com/api"
+  auth:
+    type: "api-key"
+    keySecret: "tool-server-key"
+  tools:
+    - name: web-search
+      description: "Search the web for information"
+      parameters:
+        query: string
+        maxResults: integer
+    - name: code-search
+      description: "Search code repositories"
+      parameters:
+        query: string
+        language: string
+  limits:
+    requestsPerMinute: 100
+    maxConcurrent: 10
+  metadata:
+    category: "research"
+    version: "1.0.0"
+```
+
+## Usage
+
+1. Create a namespace for your tool servers:
+   ```bash
+   kubectl create namespace kagent
+   ```
+
+2. Apply the tool server manifest:
+   ```bash
+   kubectl apply -f tool-server.yaml
+   ```
+
+3. Verify the tool server:
+   ```bash
+   kubectl get toolservers -n kagent
+   ```
+
+## Best Practices
+
+1. Secure tool server endpoints
+2. Configure proper authentication
+3. Define clear tool interfaces
+4. Set appropriate usage limits
+5. Use namespaces for organization
+
+## Related Resources
+
+- [Agent CRD](./agent) - Use tool servers
+- [Team CRD](./team) - Share tool servers
+- [ModelConfig CRD](./model-config) - Configure model tools 


### PR DESCRIPTION
# Add Comprehensive CRD Documentation

## Description
This PR adds detailed documentation for KAgent's Custom Resource Definitions (CRDs), moved from [kagent PR #335](https://github.com/kagent-dev/kagent/pull/335). The documentation covers all major CRDs used in KAgent:

- **Agent CRD**: Defines individual AI agents with their configuration, capabilities, and behavior
- **Team CRD**: Enables grouping of agents into teams for collaborative tasks
- **Memory CRD**: Configures how agents store and retrieve information
- **ModelConfig CRD**: Defines language model configurations and parameters
- **ToolServer CRD**: Manages tool server configurations for agent capabilities


