### PR TITLE
update website for CNCF transfer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Solo.io, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,350 +2,350 @@
     
     <url>
         <loc>https://kagent.dev/agents</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/blog</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/community</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/concepts/agents</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/concepts/architecture</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/concepts/memory</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/concepts</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/concepts/tools</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/examples/a2a-agents</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/examples/documentation</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/examples</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/examples/slack-a2a</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/getting-started/first-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/getting-started/first-mcp-tool</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/getting-started</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/getting-started/quickstart</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/getting-started/system-prompts</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/introduction/installation</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/introduction</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/introduction/what-is-kagent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/resources/faq</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/resources</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/resources/troubleshooting</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/anthropic</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/azure-openai</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/custom-models</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/google-vertexai</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/ollama</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers/openai</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/supported-providers</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/page.tsx</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/argo-rollouts-conversion-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/cilium-crd-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/helm-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/istio-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/k8s-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/kgateway-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/observability-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/promql-agent</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/istio</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/kubernetes</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/prometheus</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/documentation</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/helm</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/argo</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/grafana</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/other</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/cilium</loc>
-        <lastmod>2025-06-05</lastmod>
+        <lastmod>2025-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -142,7 +142,15 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-center gap-6">
           <div className="text-sm text-muted-foreground flex items-center gap-2">
             <KagentLogo animate={true} className="h-6 w-6 text-[#942DE7]" />
-            <p>is an open source project</p>
+            <p>was created at
+              <Link href="https://solo.io/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary ml-1">
+                Solo.io 
+              </Link>{' '}
+            and is a
+            <Link href="https://cncf.io/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary ml-1">
+                Cloud Native Computing Foundation
+              </Link>{' '}
+            sandbox project</p>
           </div>
           <div className="flex flex-col items-center md:items-end gap-4">
             <div className="flex items-center gap-4">
@@ -163,7 +171,10 @@ export default function Footer() {
               </Link>
             </div>
             <div className="text-sm text-muted-foreground">
-              © {new Date().getFullYear()} kagent. All rights reserved.
+              © {new Date().getFullYear()} kagent, a Series of LF Projects, LLC.
+              <Link href="https://www.linuxfoundation.org/trademark-usage/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary ml-1">
+                Trademark Usage
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Add the requisite CNCF and Linux Foundation links to the site footer.

Also fixed [a common mistake](https://github.com/kubernetes/kubernetes/pull/37305) in the Apache license included.