### PR TITLE
fix: update Jaeger namespace in tracing docs

### DIFF
--- a/src/app/docs/getting-started/tracing/page.mdx
+++ b/src/app/docs/getting-started/tracing/page.mdx
@@ -20,8 +20,6 @@ This guide will walk you through all the steps you need to get started with trac
 
 To run the AI agents you'll also need an [OpenAI](https://openai.com) API key. You can [get one here](https://platform.openai.com/account/api-keys).
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) - for interacting with your cluster
-
 ## Installing Jaeger
 
 In order to demonstrate tracing, we'll first need to install Jaeger. We will use the Jaeger all in one mode to demonstrate the tracing capabilities without needing to install any other components.
@@ -126,11 +124,10 @@ For testing purposes, we'll use the `k8s-agent` agent to get the list of pods in
 
 ![kagent UI](/images/k8s-agent-query.png "Chatting with an agent")
 
-
 Once that query is complete, we can go take a look at the data in Jaeger.
 
 ```bash
-kubectl port-forward svc/jaeger-query -n devops 16686:16686
+kubectl port-forward svc/jaeger-query -n jaeger 16686:16686
 ```
 
 Once the port-forward is set up, you can open the Jaeger UI in your browser at [http://localhost:16686](http://localhost:16686).
@@ -145,9 +142,7 @@ Once you've found the trace, you can click on it to see the details.
 
 ![Jaeger UI](/images/jaeger-trace.png "Jaeger trace details")
 
-
 That's it! You've now traced your first agent.
-
 
 ## Next Steps
 


### PR DESCRIPTION
The tracing document installs Jaeger in the `jaeger` namespace, but the port-forward command incorrectly references the `devops` namespace.