### PR TITLE
fix:Docs dropDown menu is not visible in dark mode.

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -41,7 +41,7 @@ export default function Navbar() {
                   <ChevronDown className="ml-1 w-4 h-4" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-56 bg-white shadow-md rounded-md py-2" align="start">
+              <DropdownMenuContent className="w-56 shadow-md rounded-md py-2" align="start">
                 <DropdownMenuItem 
                   onClick={() => window.location.href = '/docs/kagent'}
                   className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"


### PR DESCRIPTION
## Current website Docs dropDown menu is not visible in dark mode:
<img width="2559" height="1343" alt="Screenshot 2025-08-09 223614" src="https://github.com/user-attachments/assets/08d24d93-c4aa-4ac2-90b8-b715408fed8c" />
### But visible in light mode:
<img width="2559" height="1350" alt="Screenshot 2025-08-09 223643" src="https://github.com/user-attachments/assets/57a37685-49ad-4e53-bf3e-de2a5e96ca24" />

### After Fix:
#### In dark mode: 
<img width="2559" height="1343" alt="image" src="https://github.com/user-attachments/assets/aeaae469-6045-4a87-b5f1-eb636e750b65" />

#### In light mode:
<img width="2558" height="1346" alt="image" src="https://github.com/user-attachments/assets/53ec93b5-8523-41ea-b145-fc74608a6de0" />


