### PR TITLE
Update docs to reflect the move from AutoGen to ADK

### DIFF
--- a/src/app/docs/kagent/concepts/architecture/page.mdx
+++ b/src/app/docs/kagent/concepts/architecture/page.mdx
@@ -28,15 +28,15 @@ In the future, we envision more features for the controller, such as:
 
 ## App/Engine
 
-The kagent engine is the core component of kagent. It is a Python application that is responsible for running the agent's conversation loop. It is built on top of the [AutoGen](https://github.com/microsoft/autogen) framework. Currently, we are running the autogenstudio backend, but likely in the near future we will switch to running our own backend as the use-cases begin to diverge.
+The kagent engine is the core component of kagent. It is a Python application that is responsible for running the agent's conversation loop. It is built on top of the [ADK](https://google.github.io/adk-docs/) framework.
 
-The autogen team did a wonderful job of creating a flexible, powerful, and most importantly extensible framework for building AI agents. We take full advantage of this by using the framework by adding our own `Teams`, `Agents`, and `Tools`.
+The ADK team did a wonderful job of creating a flexible, powerful, and most importantly extensible framework for building AI agents. We take full advantage of this by using the framework by adding our own `Agents`, and `Tools`.
 
-Please see the following links for more information on the AutoGen framework:
+Please see the following links for more information on the ADK framework:
 
-- [Serializing Components](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/serialize-components.html)
-- [Component Config](https://microsoft.github.io/autogen/stable/user-guide/core-user-guide/framework/component-config.html)
-- [Autogen Agentchat](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/index.html)
+- [Agents](https://google.github.io/adk-docs/agents/)
+- [Tools](https://google.github.io/adk-docs/tools/)
+- [Context](https://google.github.io/adk-docs/context/)
 
 ## CLI
 

--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -30,7 +30,7 @@ Kagent's architecture consists of three main components:
 
 - **Tools**: Any MCP-style function that agents can leverage to interact with cloud-native systems. Kagent comes with pre-built tools that include capabilities like displaying pod logs, querying Prometheus metrics, generating resources and more. You can check the available tools in the [tool registry](/tools).
 - **Agents**: Autonomous systems that plan, execute, and analyze tasks using the available tools. These agents can chain multiple operations together to solve complex problems. Each agent can have access to one or more tools to accomplish its work. Agents can also be grouped into teams where a planning agent comes up with a plan and assigns tasks to individual agents in the team.
-- **Framework**: A flexible interface that allows running agents either through a UI or declaratively. Built on Microsoft's AutoGen framework, it provides extensive customization options.
+- **Framework**: A flexible interface that allows running agents either through a UI or declaratively. Built on Google's ADK framework, it provides extensive customization options.
 
 ## Why kagent?
 

--- a/src/app/docs/kagent/resources/helm/page.mdx
+++ b/src/app/docs/kagent/resources/helm/page.mdx
@@ -12,7 +12,7 @@ export const metadata = {
 
 # kagent
 
-A Helm chart for kagent, built with Autogen
+A Helm chart for kagent, built with ADK
 
 ## Requirements
 


### PR DESCRIPTION
Noticed on kagent github that all references to AutoGen were removed. The docs need to reflect that too.