### PR TITLE
Fix dark mode issues in navbar

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -113,7 +113,7 @@ export default function Navbar() {
                     <ChevronDown className="ml-1 w-4 h-4" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56 bg-white shadow-md rounded-md py-2" align="start">
+                <DropdownMenuContent className="w-56 shadow-md rounded-md py-2" align="start">
                   <DropdownMenuItem 
                     onClick={() => window.location.href = '/docs/kagent'}
                     className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"


### PR DESCRIPTION
This PR fixes an issue in the sidebar where the dropdown items under the "Docs" section (KAgent and KMCP) were not displaying correctly or were overlapping with other elements.

Before:
<img width="953" height="568" alt="Screenshot 2025-09-03 184259" src="https://github.com/user-attachments/assets/6ff88f34-bf6a-4345-8def-a4de6bd56f34" />

After:
<img width="795" height="486" alt="Screenshot 2025-09-03 193240" src="https://github.com/user-attachments/assets/80fe927d-cfa1-4a28-804c-a097ae23c32c" />