### PR TITLE
Docs: Update Gemini model names in providers page

### DIFF
--- a/src/app/docs/kagent/supported-providers/gemini/page.mdx
+++ b/src/app/docs/kagent/supported-providers/gemini/page.mdx
@@ -28,7 +28,7 @@ Make sure that your Google Cloud account has a project with the Gemini API enabl
 
 3. Create a ModelConfig resource using the `Gemini` provider. The following Gemini models are supported:
 
-All gemini models support multimodal inputs (imags, audio, video, text).
+All gemini models support multimodal inputs (imags, audio, video, text), more information regarding model choices can be found on the [Gemini API docs](https://ai.google.dev/gemini-api/docs/models).
 
 - **gemini-2.5-pro** - Thinking and reasoning, multimodal understanding, advanced coding
 - **gemini-2.5-flash** - Adaptive thinking, cost efficiency

--- a/src/app/docs/kagent/supported-providers/gemini/page.mdx
+++ b/src/app/docs/kagent/supported-providers/gemini/page.mdx
@@ -26,15 +26,9 @@ Make sure that your Google Cloud account has a project with the Gemini API enabl
    kubectl create secret generic kagent-gemini -n kagent --from-literal GOOGLE_API_KEY=<your_api_key>
    ```
 
-3. Create a ModelConfig resource using the `Gemini` provider. The following Gemini models are supported:
+3. Create a ModelConfig resource using the `Gemini` provider.
 
-All gemini models support multimodal inputs (imags, audio, video, text), more information regarding model choices can be found on the [Gemini API docs](https://ai.google.dev/gemini-api/docs/models).
-
-- **gemini-2.5-pro** - Thinking and reasoning, multimodal understanding, advanced coding
-- **gemini-2.5-flash** - Adaptive thinking, cost efficiency
-- **gemini-2.5-flash-lite** - Most cost-efficient model supporting high throughput
-- **gemini-2.0-flash** - Text generation
-- **gemini-2.0-flash-lite** - Cost efficiency and low latency
+You can find out the latest model names and capabilities on the [Gemini API docs](https://ai.google.dev/gemini-api/docs/models). Once you have chosen a model, replace the `model` field with the name such as `gemini-2.5-pro`.
 
 ```yaml
 apiVersion: kagent.dev/v1alpha2

--- a/src/app/docs/kagent/supported-providers/gemini/page.mdx
+++ b/src/app/docs/kagent/supported-providers/gemini/page.mdx
@@ -7,7 +7,7 @@ description: "Learn how to configure Gemini models in kagent."
 export const metadata = {
   title: "Configuring Gemini models in kagent",
   description: "Learn how to configure Gemini models in kagent.",
-  author: "kagent.dev"
+  author: "kagent.dev",
 };
 
 Gemini is Google's AI model family that can be accessed directly through the Google AI Studio API.
@@ -28,19 +28,28 @@ Make sure that your Google Cloud account has a project with the Gemini API enabl
 
 3. Create a ModelConfig resource using the `Gemini` provider. The following Gemini models are supported:
 
-   - **gemini-pro** - Text generation with function calling support
-   - **gemini-pro-vision** - Multimodal model for text and image processing
+All gemini models support multimodal inputs (imags, audio, video, text).
 
-   ```yaml
-   apiVersion: kagent.dev/v1alpha2
-   kind: ModelConfig
-   metadata:
-     name: gemini-model-config
-     namespace: kagent
-   spec:
-     apiKeySecret: kagent-gemini
-     apiKeySecretKey: GOOGLE_API_KEY
-     model: gemini-pro
-     provider: Gemini
-     gemini: {}
-   ```
+- **gemini-2.5-pro** - Thinking and reasoning, multimodal understanding, advanced coding
+- **gemini-2.5-flash** - Adaptive thinking, cost efficiency
+- **gemini-2.5-flash-lite** - Most cost-efficient model supporting high throughput
+- **gemini-2.0-flash** - Text generation
+- **gemini-2.0-flash-lite** - Cost efficiency and low latency
+
+```yaml
+apiVersion: kagent.dev/v1alpha2
+kind: ModelConfig
+metadata:
+  name: gemini-model-config
+  namespace: kagent
+spec:
+  apiKeySecret: kagent-gemini
+  apiKeySecretKey: GOOGLE_API_KEY
+  model: gemini-2.5-flash
+  provider: Gemini
+  gemini: {}
+```
+
+4. Apply the above resource to the cluster.
+
+Once the resource is applied, you can select the model from the Model dropdown in the UI when creating or updating agents.


### PR DESCRIPTION
This PR closes #194 and resolves a frequent issue encountered when setting up Gemini as a provider. The current documentation references outdated model names, which often leads to errors and confusion for new users.

This update aligns the model names and descriptions with the official Gemini API documentation: https://ai.google.dev/gemini-api/docs/models

Since Gemini is a common starting point for many users with its free API key, having accurate setup instructions is essential. The updated documentation is included below.

<img width="799" height="664" alt="Screenshot 2025-09-03 at 9 58 56 PM" src="https://github.com/user-attachments/assets/099b7b46-8916-4f68-a2d2-5b61f6d21cce" />
