### PR TITLE
fix: navbar active state colors

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,525 +2,525 @@
     
     <url>
         <loc>https://kagent.dev/agents</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/blog</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/community</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agents</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/architecture</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/tools</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-agents</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-byo</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/discord-a2a</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/documentation</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/slack-a2a</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-mcp-tool</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/quickstart</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/system-prompts</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/tracing</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/installation</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/what-is-kagent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/api-ref</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/faq</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/helm</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/release-notes</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/troubleshooting</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/anthropic</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/azure-openai</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/gemini</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/google-vertexai</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/ollama</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/openai</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/install-controller</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/server</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/fastmcp-python</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/mcp-go</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/introduction</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/quickstart</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/api-ref</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-add-tool</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-build</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-deploy</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-init</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-install</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-run</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-secrets</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/secrets</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/page.tsx</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/argo-rollouts-conversion-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/cilium-crd-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/helm-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/istio-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/k8s-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/kgateway-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/observability-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/promql-agent</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/istio</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/kubernetes</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/prometheus</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/documentation</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/helm</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/argo</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/grafana</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/other</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/cilium</loc>
-        <lastmod>2025-09-03</lastmod>
+        <lastmod>2025-09-10</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { GITHUB_LINK } from "@/data/links";
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import KAgentLogoWithText from "./icons/kagent-logo-text";
 import KagentLogo from "./icons/kagent-logo";
 import KMCPIcon from "./icons/kmcpicon";
@@ -18,6 +19,12 @@ import {
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  const isActive = (href: string) => {
+    if (href === "/") return pathname === "/";
+    return pathname.startsWith(href);
+  };
 
   return (
     <nav className="py-4 md:py-8">
@@ -26,50 +33,112 @@ export default function Navbar() {
           <Link href="/">
             <KAgentLogoWithText className="h-5" />
           </Link>
+
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center space-x-4 lg:space-x-8">
-            <Button variant="link" className="text-secondary-foreground" asChild>
+            <Button
+              variant="link"
+              className={`${
+                isActive("/blog")
+                  ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                  : "text-secondary-foreground"
+              }`}
+              asChild
+            >
               <Link href="/blog">Blog</Link>
             </Button>
+
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="link"
-                  className="text-secondary-foreground flex items-center"
+                  className={`flex items-center ${
+                    pathname.startsWith("/docs")
+                      ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                      : "text-secondary-foreground"
+                  }`}
                 >
                   Docs
                   <ChevronDown className="ml-1 w-4 h-4" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-56 shadow-md rounded-md py-2" align="start">
-                <DropdownMenuItem 
-                  onClick={() => window.location.href = '/docs/kagent'}
-                  className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"
+              <DropdownMenuContent
+                className="w-56 shadow-md rounded-md py-2"
+                align="start"
+              >
+                <DropdownMenuItem
+                  onClick={() => (window.location.href = "/docs/kagent")}
+                  className={`flex items-center space-x-2 cursor-pointer transition-colors group ${
+                    pathname.startsWith("/docs/kagent")
+                      ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                      : "hover:bg-primary/10"
+                  }`}
                 >
                   <KagentLogo className="w-4 h-4 transition-colors group-hover:text-primary" />
                   <span>kagent</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem 
-                  onClick={() => window.location.href = '/docs/kmcp'}
-                  className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"
+                <DropdownMenuItem
+                  onClick={() => (window.location.href = "/docs/kmcp")}
+                  className={`flex items-center space-x-2 cursor-pointer transition-colors group ${
+                    pathname.startsWith("/docs/kmcp")
+                      ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                      : "hover:bg-primary/10"
+                  }`}
                 >
                   <KMCPIcon className="w-4 h-4 transition-colors group-hover:text-primary" />
                   <span>kMCP</span>
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button variant="link" className="text-secondary-foreground" asChild>
+
+            <Button
+              variant="link"
+              className={`${
+                isActive("/tools")
+                  ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                  : "text-secondary-foreground"
+              }`}
+              asChild
+            >
               <Link href="/tools">Tools</Link>
             </Button>
-            <Button variant="link" className="text-secondary-foreground" asChild>
+
+            <Button
+              variant="link"
+              className={`${
+                isActive("/agents")
+                  ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                  : "text-secondary-foreground"
+              }`}
+              asChild
+            >
               <Link href="/agents">Agents</Link>
             </Button>
-            <Button variant="link" className="text-secondary-foreground" asChild>
+
+            <Button
+              variant="link"
+              className={`${
+                isActive(GITHUB_LINK)
+                  ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                  : "text-secondary-foreground"
+              }`}
+              asChild
+            >
               <Link href={GITHUB_LINK}>GitHub</Link>
             </Button>
-            <Button variant="link" className="text-secondary-foreground" asChild>
+
+            <Button
+              variant="link"
+              className={`${
+                isActive("/community")
+                  ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                  : "text-secondary-foreground"
+              }`}
+              asChild
+            >
               <Link href="/community">Community</Link>
             </Button>
+
             <DocSearch
               appId="0Q0AZY5UR3"
               indexName="kagent"
@@ -78,7 +147,9 @@ export default function Navbar() {
 
             <ThemeToggle />
             <Button variant="secondary" asChild>
-              <Link href="/docs/kagent/getting-started/quickstart">Get Started</Link>
+              <Link href="/docs/kagent/getting-started/quickstart">
+                Get Started
+              </Link>
             </Button>
           </div>
 
@@ -100,50 +171,113 @@ export default function Navbar() {
         {isMenuOpen && (
           <div className="md:hidden pt-4 pb-2">
             <div className="flex flex-col space-y-2">
-              <Button variant="ghost" className="justify-start" asChild>
+              <Button
+                variant="ghost"
+                className={`justify-start ${
+                  isActive("/blog")
+                    ? "font-bold text-primary underline decoration-white underline-offset-4"
+                    : ""
+                }`}
+                asChild
+              >
                 <Link href="/blog">Blog</Link>
               </Button>
+
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
-                    className="justify-start flex items-center"
+                    className={`justify-start flex items-center ${
+                      pathname.startsWith("/docs")
+                        ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                        : ""
+                    }`}
                   >
                     Docs
                     <ChevronDown className="ml-1 w-4 h-4" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56 shadow-md rounded-md py-2" align="start">
-                  <DropdownMenuItem 
-                    onClick={() => window.location.href = '/docs/kagent'}
-                    className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"
+                <DropdownMenuContent
+                  className="w-56 shadow-md rounded-md py-2"
+                  align="start"
+                >
+                  <DropdownMenuItem
+                    onClick={() => (window.location.href = "/docs/kagent")}
+                    className={`flex items-center space-x-2 cursor-pointer transition-colors group ${
+                      pathname.startsWith("/docs/kagent")
+                        ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                        : "hover:bg-primary/10"
+                    }`}
                   >
                     <KagentLogo className="w-4 h-4 transition-colors group-hover:text-primary" />
                     <span>KAgent</span>
                   </DropdownMenuItem>
-                  <DropdownMenuItem 
-                    onClick={() => window.location.href = '/docs/kmcp'}
-                    className="flex items-center space-x-2 hover:bg-primary/10 cursor-pointer transition-colors group"
+                  <DropdownMenuItem
+                    onClick={() => (window.location.href = "/docs/kmcp")}
+                    className={`flex items-center space-x-2 cursor-pointer transition-colors group ${
+                      pathname.startsWith("/docs/kmcp")
+                        ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                        : "hover:bg-primary/10"
+                    }`}
                   >
                     <KMCPIcon className="w-4 h-4 transition-colors group-hover:text-primary" />
                     <span>KMCP</span>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Button variant="ghost" className="justify-start" asChild>
+
+              <Button
+                variant="ghost"
+                className={`justify-start ${
+                  isActive("/tools")
+                    ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                    : ""
+                }`}
+                asChild
+              >
                 <Link href="/tools">Tools</Link>
               </Button>
-              <Button variant="ghost" className="justify-start" asChild>
+
+              <Button
+                variant="ghost"
+                className={`justify-start ${
+                  isActive("/agents")
+                    ? "font-bold text-primary underline decoration-primary underline-offset-4"
+                    : ""
+                }`}
+                asChild
+              >
                 <Link href="/agents">Agents</Link>
               </Button>
-              <Button variant="ghost" className="justify-start" asChild>
+
+              <Button
+                variant="ghost"
+                className={`justify-start ${
+                  isActive(GITHUB_LINK)
+                    ? "font-bold text-primary underline decoration-white underline-offset-4"
+                    : ""
+                }`}
+                asChild
+              >
                 <Link href={GITHUB_LINK}>GitHub</Link>
               </Button>
-              <Button variant="ghost" className="justify-start" asChild>
+
+              <Button
+                variant="ghost"
+                className={`justify-start ${
+                  isActive("/community")
+                    ? "font-bold text-primary underline decoration-white underline-offset-4"
+                    : ""
+                }`}
+                asChild
+              >
                 <Link href="/community">Community</Link>
               </Button>
+
               <Button variant="secondary" className="mt-4" asChild>
-                <Link href="/docs/kagent/getting-started/quickstart">Get Started</Link>
+                <Link href="/docs/kagent/getting-started/quickstart">
+                  Get Started
+                </Link>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Highlight the active navigation item with bold text + theme-colored underline using usePathname. Replaced hard-coded white with text-primary so it works in light mode too. No structural changes, just improved UX.

Before:
<img width="1317" height="237" alt="Screenshot 2025-09-10 153636" src="https://github.com/user-attachments/assets/17368d18-10dd-4736-aae9-d430499d2372" />

After:
<img width="1572" height="182" alt="Screenshot 2025-09-10 153608" src="https://github.com/user-attachments/assets/b394c028-0d63-45c0-8c0a-e529d54191b3" />
