### PR TITLE
Preserve backticks in Helm ref docs

### DIFF
--- a/.github/workflows/update-ref-docs.yaml
+++ b/.github/workflows/update-ref-docs.yaml
@@ -224,9 +224,6 @@ jobs:
             # (might be replaced by helm docs template in the future)
             sed -i '/!\[Version:/,/^$/d' "src/app/docs/kagent/resources/helm/temp.mdx"
 
-            # Remove backticks from the Default column in the table
-            sed -i 's/| `\([^`]*\)` |/| \1 |/g' "src/app/docs/kagent/resources/helm/temp.mdx"
-
             # Add frontmatter
             echo '---' > "src/app/docs/kagent/resources/helm/page.mdx"
             echo 'title: "Helm Chart Configuration"' >> "src/app/docs/kagent/resources/helm/page.mdx"

--- a/src/app/docs/kagent/resources/helm/page.mdx
+++ b/src/app/docs/kagent/resources/helm/page.mdx
@@ -30,7 +30,7 @@ A Helm chart for kagent, built with Google ADK
 | file://../agents/promql | promql-agent |  |
 | file://../tools/grafana-mcp | grafana-mcp |  |
 | file://../tools/querydoc | querydoc |  |
-| oci://ghcr.io/kagent-dev/kmcp/helm | kmcp | ${KMCP_VERSION} |
+| oci://ghcr.io/kagent-dev/kmcp/helm | kmcp | `${KMCP_VERSION}` |
 | oci://ghcr.io/kagent-dev/tools/helm | kagent-tools | 0.0.12 |
 
 ## Values


### PR DESCRIPTION
The Cloudflare builds were failing, and I noticed this error in them:
```
2025-12-05T16:56:27.380Z	Error occurred prerendering page "/docs/kagent/resources/helm". Read more: https://nextjs.org/docs/messages/prerender-error
2025-12-05T16:56:27.381Z	ReferenceError: KMCP_VERSION is not defined
2025-12-05T16:56:27.381Z	    at g (.next/server/app/docs/kagent/resources/helm/page.js:1:3812)
2025-12-05T16:56:27.381Z	    at h (.next/server/app/docs/kagent/resources/helm/page.js:1:37261)
2025-12-05T16:56:27.381Z	    at stringify (<anonymous>) {
2025-12-05T16:56:27.382Z	  digest: '3541987100'
2025-12-05T16:56:27.382Z	}
```

the update-ref-docs was removing backticks from the Helm ref docs, I'm not sure why. But I think adding it will prevent the build from thinking this `${KMCP_VERSION}` variable is jsx that it needs to interpret.

Builds locally for me:
<img width="1000" height="159" alt="image" src="https://github.com/user-attachments/assets/b86b7226-8af8-4a91-9917-cbff60211735" />
