### PR TITLE
fix: correct Contributing link filename

### DIFF
--- a/scripts/generate-nav.mjs
+++ b/scripts/generate-nav.mjs
@@ -99,7 +99,7 @@ async function buildNavigation() {
           const installationIndex = subSectionItems.findIndex(item => item.title.toLowerCase() === 'installation');
           const hardcodedItems = [
               { title: "Feature Roadmap", href: "https://github.com/kagent-dev/kagent/blob/main/README.md#roadmap", order: installationIndex !== -1 ? installationIndex + 1 : Infinity, external: true },
-              { title: "Contributing", href: "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md", order: installationIndex !== -1 ? installationIndex + 2 : Infinity, external: true },
+              { title: "Contributing", href: "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md", order: installationIndex !== -1 ? installationIndex + 2 : Infinity, external: true },
           ];
           subSectionItems.push(...hardcodedItems);
           subSectionItems.sort((a, b) => a.order - b.order); // Re-sort after adding

--- a/src/app/docs/kagent/introduction/page.mdx
+++ b/src/app/docs/kagent/introduction/page.mdx
@@ -22,6 +22,6 @@ import QuickLink from '@/components/quick-link';
     <QuickLink title="What is kagent?" description="Learn about the core concepts and capabilities of kagent." href="/docs/kagent/introduction/what-is-kagent" />
     <QuickLink title="Installation" description="Follow our guide to set up kagent." href="/docs/kagent/introduction/installation" />
     <QuickLink title="Feature Roadmap" description="See what we're planning for the future." href="https://github.com/kagent-dev/kagent/blob/main/README.md#roadmap" />
-    <QuickLink title="Contributing" description="Find out how you can help improve kagent." href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md" />
+    <QuickLink title="Contributing" description="Find out how you can help improve kagent." href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md" />
     </div>
 </div> 

--- a/src/app/docs/kagent/resources/faq/page.mdx
+++ b/src/app/docs/kagent/resources/faq/page.mdx
@@ -30,4 +30,4 @@ The best way to report bugs or request features is to create an issue on the [Gi
 
 ## How do I contribute to the kagent project?
 
-The best way to contribute is to check out the [contribution guide](https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md) and submit a PR.
+The best way to contribute is to check out the [contribution guide](https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md) and submit a PR.

--- a/src/app/docs/kagent/resources/page.mdx
+++ b/src/app/docs/kagent/resources/page.mdx
@@ -26,7 +26,7 @@ import QuickLink from '@/components/quick-link';
     <QuickLink title="Release Notes" description="Review the release notes for kagent." href="/docs/kagent/resources/release-notes" />
     <QuickLink title="Quick Start Guide" description="Get up and running quickly with kagent." href="/docs/kagent/getting-started/quickstart" />
     <QuickLink title="Official GitHub Repository" description="Access the source code and contribute to kagent development." href="https://github.com/kagent-dev/kagent" />
-    <QuickLink title="Contribution Guide" description="Learn how to contribute to the kagent project." href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md" />
+    <QuickLink title="Contribution Guide" description="Learn how to contribute to the kagent project." href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md" />
     <QuickLink title="Join our Discord Community" description="Connect with other kagent users and developers." href="https://discord.gg/Fu3k65f2k3" />
     </div>
 </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -124,7 +124,7 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md" target="_blank" rel="noopener noreferrer" className="text-sm text-muted-foreground hover:text-primary">
+                <Link href="https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-muted-foreground hover:text-primary">
                   Contributing
                 </Link>
               </li>

--- a/src/config/navigation.json
+++ b/src/config/navigation.json
@@ -27,7 +27,7 @@
           },
           {
             "title": "Contributing",
-            "href": "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md",
+            "href": "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md",
             "external": true
           }
         ]


### PR DESCRIPTION
Hello. This is my first PR. Thank you for all your development.

## Overview

Fix broken Contributing links across the website by correcting the filename from `CONTRIBUTION.md` to `CONTRIBUTING.md`.

## Description of Change

### Updated Contributing link URLs

The Contributing guide link was pointing to a non-existent file (`CONTRIBUTION.md`). This file was renamed to `CONTRIBUTING.md` in the kagent repository on commit [2cbb6cf](https://github.com/kagent-dev/kagent/commit/2cbb6cf1a178a33ee4b0f261bfccfa33dcf51c49).

Updated all occurrences to use the correct filename in the following locations:

- `scripts/generate-nav.mjs` - Navigation generator script
- `src/app/docs/kagent/introduction/page.mdx` - Introduction page QuickLinks
- `src/app/docs/kagent/resources/faq/page.mdx` - FAQ page
- `src/app/docs/kagent/resources/page.mdx` - Resources page QuickLinks
- `src/components/footer.tsx` - Site footer
- `src/config/navigation.json` - Navigation configuration (generated by `scripts/generate-nav.mjs`)

## Confirmation of operation

- [x] Verify Contributing links targets correctly "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md" on each page
  - [x] Footer: (scroll to footer, click "Contributing")
  - [x] Introduction page: /docs/kagent/introduction
  - [x] Resources page: /docs/kagent/resources
  - [x] FAQ page: /docs/kagent/resources/faq
  - [x] Left navigation bar: /docs/kagent/introduction (click "Contributing" in the left sidebar)