### PR TITLE
Fix link to CONTRIBUTING.md in navigation.json

### DIFF
--- a/src/config/navigation.json
+++ b/src/config/navigation.json
@@ -27,7 +27,7 @@
           },
           {
             "title": "Contributing",
-            "href": "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTION.md",
+            "href": "https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md",
             "external": true
           }
         ]


### PR DESCRIPTION
404 when I try to reach the contribution section from the docs website. 