### PR TITLE
docs: clarify Bedrock IAM role support

### DIFF
--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -16,9 +16,11 @@ You can use Amazon Bedrock models with kagent in two ways: the native Bedrock pr
 
 ## Option 1: Native Bedrock provider
 
-The native Bedrock provider uses AWS IAM credentials and the Bedrock API directly. Use this option when you want the simplest configuration and full Bedrock feature support.
+The native Bedrock provider uses the standard AWS credential chain and the Bedrock API directly. Use this option when you want the simplest configuration and full Bedrock feature support.
 
-### Step 1: Prepare your AWS credentials
+On Kubernetes, the recommended setup is to use an IAM role attached to the agent's ServiceAccount, such as [EKS IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). Use static access keys only when workload identity is not available.
+
+### Step 1: Prepare AWS access
 
 1. Create an IAM user or role with permissions for Bedrock. You need at least `bedrock:InvokeModel` for the models you use. For more information, see the [AWS Bedrock model access docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html).
 
@@ -26,13 +28,17 @@ The native Bedrock provider uses AWS IAM credentials and the Bedrock API directl
    - Example regions: `us-east-1` or `us-west-2`
    - Example model IDs: `us.anthropic.claude-sonnet-4-20250514-v1:0` or `amazon.titan-text-express-v1`
 
-3. Create a Kubernetes secret with your AWS credentials in the same namespace as your agent, typically `kagent`:
+3. Choose how the agent will authenticate to AWS:
+   - Recommended: attach an IAM role to the agent ServiceAccount using workload identity, such as EKS IRSA.
+   - Alternative: create a Kubernetes secret with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
-   ```bash
-   kubectl create secret generic bedrock-credentials -n kagent \
-     --from-literal=AWS_ACCESS_KEY_ID=<your-access-key> \
-     --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-key>
-   ```
+If you are using access keys, create the secret in the same namespace as your agent, typically `kagent`:
+
+```bash
+kubectl create secret generic bedrock-credentials -n kagent \
+  --from-literal=AWS_ACCESS_KEY_ID=<your-access-key> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-key>
+```
 
 ### Step 2: Create the ModelConfig
 
@@ -46,18 +52,59 @@ metadata:
 spec:
   provider: Bedrock
   model: us.anthropic.claude-sonnet-4-20250514-v1:0
-  apiKeySecret: bedrock-credentials
   bedrock:
     region: us-east-1
 EOF
 ```
 
+If you are using access keys instead of an IAM role, add `apiKeySecret: bedrock-credentials` to the `ModelConfig` spec.
+
 | Setting | Description |
 | --- | --- |
 | `provider` | Set to `Bedrock` for the native provider. |
 | `model` | The Bedrock model ID. Use the format from the [AWS Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html) (for example, `us.anthropic.claude-sonnet-4-20250514-v1:0`). |
-| `apiKeySecret` | The name of the Kubernetes secret containing `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. |
+| `apiKeySecret` | Optional. Set this when using a Kubernetes secret that contains `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Omit it when the agent uses the pod's AWS credential chain, such as an IAM role attached to the ServiceAccount. |
 | `bedrock.region` | The AWS region where the Bedrock model is available (for example, `us-east-1`). |
+
+### Step 3: Configure the agent to use an IAM role
+
+If you already have a ServiceAccount that is configured for workload identity, reference it from the agent:
+
+```yaml
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bedrock-agent
+  namespace: kagent
+spec:
+  type: Declarative
+  declarative:
+    modelConfig: bedrock-native
+    systemMessage: You are a helpful assistant.
+    deployment:
+      serviceAccountName: bedrock-irsa
+```
+
+If you want kagent to create the ServiceAccount for the agent, you can add the workload identity annotation through `serviceAccountConfig`:
+
+```yaml
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bedrock-agent
+  namespace: kagent
+spec:
+  type: Declarative
+  declarative:
+    modelConfig: bedrock-native
+    systemMessage: You are a helpful assistant.
+    deployment:
+      serviceAccountConfig:
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/kagent-bedrock
+```
+
+If you want to use one shared ServiceAccount for multiple agents, you can also set `controller.agentDeployment.serviceAccountName` in the [Helm chart configuration](/docs/kagent/resources/helm).
 
 ## Option 2: OpenAI-compatible API
 


### PR DESCRIPTION
Refs #349

This MR improves the Amazon Bedrock docs for kagent by making the Kubernetes authentication story clearer. The current docs can be read as if IRSA/workload identity is not supported, which may lead users toward access keys and Kubernetes secrets as the primary setup. These changes clarify that IRSA is supported today and should generally be the preferred approach for Kubernetes deployments.

The update also explains that Bedrock uses the standard AWS credential chain, adds IAM role and ServiceAccount-based setup examples, and makes apiKeySecret guidance more precise by noting that it is optional and only needed when using static access keys.

cc @boriscosic