### PR TITLE
Fix what-is-kagent description (open-source K8s-native framework)

### DIFF
--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -14,7 +14,7 @@ import FeatureGrid from '@/components/mdx/feature-grid';
 
 # Introducing kagent
 
-kagent is an open-source programming framework that brings the power of agentic AI to cloud-native environments. Built specifically for DevOps and platform engineers, kagent enables AI agents to run directly in Kubernetes clusters to automate operations, troubleshoot issues, and solve complex cloud-native challenges.
+kagent is an open-source Kubernetes native framework for building AI agents and harnesses. Kubernetes is the most popular orchestration platform for running workloads, and kagent makes it easy to build, deploy and manage AI agents and harnesses in Kubernetes. The kagent framework is designed to be easy to understand and use, and to provide a flexible and powerful way to build and manage AI agents and harnesses.
 
 kagent was created at [Solo.io](https://www.solo.io) in 2025 and is a [Cloud Native Computing Foundation](https://www.cncf.io) sandbox project.
 

--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -14,7 +14,7 @@ import FeatureGrid from '@/components/mdx/feature-grid';
 
 # Introducing kagent
 
-kagent is an open-source Kubernetes native framework for building AI agents and harnesses. Kubernetes is the most popular orchestration platform for running workloads, and kagent makes it easy to build, deploy and manage AI agents and harnesses in Kubernetes. The kagent framework is designed to be easy to understand and use, and to provide a flexible and powerful way to build and manage AI agents and harnesses.
+kagent is an open-source Kubernetes native framework for building AI agents and harnesses (e.g. NemoClaw, OpenClaw). Kubernetes is the most popular orchestration platform for running workloads, and kagent makes it easy to build, deploy and manage AI agents and harnesses in Kubernetes. The kagent framework is designed to be easy to understand and use, and to provide a flexible and powerful way to build and manage AI agents and harnesses.
 
 kagent was created at [Solo.io](https://www.solo.io) in 2025 and is a [Cloud Native Computing Foundation](https://www.cncf.io) sandbox project.
 

--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -14,7 +14,7 @@ import FeatureGrid from '@/components/mdx/feature-grid';
 
 # Introducing kagent
 
-kagent is an open-source Kubernetes native framework for building AI agents and harnesses (e.g. NemoClaw, OpenClaw). Kubernetes is the most popular orchestration platform for running workloads, and kagent makes it easy to build, deploy and manage AI agents and harnesses in Kubernetes. The kagent framework is designed to be easy to understand and use, and to provide a flexible and powerful way to build and manage AI agents and harnesses.
+kagent is an open-source, Kubernetes-native framework for building AI agents and harnesses — production-ready agent runtimes like NemoClaw and OpenClaw. It lets platform and DevOps teams deploy, scale, and operate agents as first-class Kubernetes resources, using the same primitives (CRDs, RBAC, GitOps, observability) they already use for every other workload.
 
 kagent was created at [Solo.io](https://www.solo.io) in 2025 and is a [Cloud Native Computing Foundation](https://www.cncf.io) sandbox project.
 

--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -14,7 +14,7 @@ import FeatureGrid from '@/components/mdx/feature-grid';
 
 # Introducing kagent
 
-kagent is an open-source, Kubernetes-native framework for building AI agents and harnesses — production-ready agent runtimes like NemoClaw and OpenClaw. It lets platform and DevOps teams deploy, scale, and operate agents as first-class Kubernetes resources, using the same primitives (CRDs, RBAC, GitOps, observability) they already use for every other workload.
+kagent is an open-source, Kubernetes-native runtime for AI agents. Deploy, scale, and operate agents as first-class Kubernetes resources by using the same CRDs, RBAC, GitOps, and observability you already use for your other workloads. Manage everything your agents need: agent harnesses, MCP tool servers, memory, and more. kagent works out of the box with many of the most popular AI projects: runtimes like NemoClaw and OpenClaw, agent frameworks like ADK and LangGraph, and many LLM providers like OpenAI, Anthropic, Gemini, and more.
 
 kagent was created at [Solo.io](https://www.solo.io) in 2025 and is a [Cloud Native Computing Foundation](https://www.cncf.io) sandbox project.
 


### PR DESCRIPTION
## Summary
- Rewrites the opening paragraph of `docs/kagent/introduction/what-is-kagent` so it matches how the rest of the site positions kagent.
- Old copy called kagent an "open-source programming framework" for "DevOps and platform engineers," which contradicted the homepage's BYO-frameworks story (LangGraph / CrewAI / ADK) and made the page feel inconsistent.
- New copy frames kagent as an open-source Kubernetes native framework for building AI agents and harnesses.

## Test plan
- [ ] `npm run dev` and visit `/docs/kagent/introduction/what-is-kagent` — verify the new opening paragraph renders correctly
- [ ] Confirm metadata / page title still render
- [ ] Sanity-check dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)