### PR TITLE
fix(footer): update trademark link to LF Projects policies

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -177,7 +177,7 @@ export default function Footer() {
             </div>
             <div className="text-sm text-muted-foreground">
               © {new Date().getFullYear()} kagent, a Series of LF Projects, LLC.
-              <Link href="https://www.linuxfoundation.org/trademark-usage/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary ml-1">
+              <Link href="https://lfprojects.org/policies/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary ml-1">
                 Trademark Usage
               </Link>
             </div>


### PR DESCRIPTION
Fixes #369

## Summary

- Updates the footer "Trademark Usage" link in `src/components/footer.tsx` from `https://www.linuxfoundation.org/trademark-usage/` to `https://lfprojects.org/policies/`.
- Aligns the link with the LF Projects, LLC policies site referenced in the issue. The copyright line already states "kagent, a Series of LF Projects, LLC."
- No other footer copy, layout, or files were changed.

## Test plan

- [x] `npm run dev`
- [x] Open any page (for example `/`) and scroll to the footer
- [x] Click "Trademark Usage" and confirm it opens `https://lfprojects.org/policies/` in a new tab
- [x] `npm run lint` (no new lint issues expected)