### PR TITLE
Removed PR link for RemoteMCPServer

### DIFF
--- a/src/app/docs/kagent/resources/release-notes/page.mdx
+++ b/src/app/docs/kagent/resources/release-notes/page.mdx
@@ -143,7 +143,7 @@ Before you upgrade:
 * **AWS LoadBalancer annotations** — the UI Service now supports AWS LoadBalancer service annotations for easier AWS deployment.
 * **SSH auth for git-based skills** — fixed SSH authentication when loading skills from private Git repositories.
 * **MCP connection error handling** — MCP connection errors are now returned to the LLM as context instead of raising exceptions.
-* **RemoteMCPServer TLS (v0.9.6)** — you can now connect to an MCP server that uses a private CA, self-signed certificate, or corporate internal CA by setting the `spec.tls` field on a `RemoteMCPServer`. The `spec.tls` shape mirrors the `ModelConfig` TLS configuration. For details, see kagent PR [#1905](https://github.com/kagent-dev/kagent/pull/1905).
+* **RemoteMCPServer TLS (v0.9.6)** — you can now connect to an MCP server that uses a private CA, self-signed certificate, or corporate internal CA by setting the `spec.tls` field on a `RemoteMCPServer`. The `spec.tls` shape mirrors the `ModelConfig` TLS configuration.
 
 # v0.8
 


### PR DESCRIPTION
Not necessary to link to the PR from the release notes.