### PR TITLE
Add Agent Substrate to homepage and core concepts

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,826 +2,826 @@
     
     <url>
         <loc>https://kagent.dev/agents</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/blog</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/community</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-harness</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-memory</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agents</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/architecture</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/tools</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-agents</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-byo</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-harness</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-sandbox</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agents-mcp</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/crewai-byo</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/discord-a2a</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/documentation</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/human-in-the-loop</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/langchain-byo</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/skills</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/slack-a2a</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/telegram-bot</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-mcp-tool</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/local-development</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/quickstart</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/system-prompts</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/features</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/installation</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/what-is-kagent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/audit-prompts</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/launch-ui</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/tracing</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/debug</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/operational-considerations</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/uninstall</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/upgrade</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/api-ref</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-add-mcp</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-bug-report</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-build</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-completion</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-dashboard</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-deploy</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-get</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-help</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-init</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-install</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-invoke</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-mcp</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-run</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-uninstall</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-version</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/faq</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/helm</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/release-notes</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/tools-ecosystem</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/amazon-bedrock</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/anthropic</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/azure-openai</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/byo-openai</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/gemini</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/google-vertexai</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/ollama</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/openai</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/sap-ai-core</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/xai</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/install-controller</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/server</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/fastmcp-python</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/mcp-go</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/introduction</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/quickstart</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/api-ref</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-add-tool</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-build</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-completion</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-deploy</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-help</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-init</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-install</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-run</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-secrets</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/secrets</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/enterprise</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/page.tsx</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/argo-rollouts-conversion-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/cilium-crd-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/helm-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/istio-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/k8s-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/kgateway-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/observability-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/promql-agent</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/istio</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/kubernetes</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/prometheus</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/documentation</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/helm</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/argo</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/grafana</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/other</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/cilium</loc>
-        <lastmod>2026-05-26</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/src/app/docs/kagent/concepts/agent-memory/page.mdx
+++ b/src/app/docs/kagent/concepts/agent-memory/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Memory"
-pageOrder: 5
+pageOrder: 6
 description: "Enable vector-backed long-term memory for agents to learn from past interactions."
 ---
 

--- a/src/app/docs/kagent/concepts/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/concepts/agent-substrate/page.mdx
@@ -14,7 +14,10 @@ export const metadata = {
 
 Agent Substrate is a Kubernetes-native runtime for running AI agents and other stateful workloads efficiently. Instead of dedicating one pod per agent — which wastes capacity while agents sit idle — Substrate decouples an agent's lifecycle from pod infrastructure. Idle agents are snapshotted to object storage and rehydrated on demand, so a small pool of pre-warmed workers can host far more agents than there are pods.
 
-kagent can run a declarative agent directly on Agent Substrate by selecting it as the [`AgentHarness`](/docs/kagent/concepts/agent-harness) runtime. When `runtime` is set to `substrate`, kagent generates a per-harness `ActorTemplate` and creates an `Actor` from it, referencing a `WorkerPool` for capacity.
+kagent can run workloads on Agent Substrate in two ways:
+
+- **Declarative agents** — A declarative `Agent` describes its model, instructions, and tools (see [Agents](/docs/kagent/concepts/agents)). Its sandboxed variant, the [`SandboxAgent`](/docs/kagent/resources/api-ref) CRD, lets you run a (Go) declarative agent on Agent Substrate.
+- **AgentHarness** — The [`AgentHarness`](/docs/kagent/concepts/agent-harness) CRD provisions a long-running execution environment. Select Agent Substrate as its runtime by setting `runtime` to `substrate`; kagent then generates a per-harness `ActorTemplate` and creates an `Actor` from it, referencing a `WorkerPool` for capacity.
 
 ## Why Agent Substrate
 
@@ -56,7 +59,13 @@ Agent Substrate is composed of a control plane, a data plane, and snapshot stora
 
 - Zstd-compressed checkpoint snapshots stored in object storage (GCS or S3).
 
-## Using Agent Substrate with an AgentHarness
+## Using Agent Substrate with AgentHarness and Declarative agents
+
+### Declarative agents
+
+Run a (Go) declarative agent on Agent Substrate by creating a `SandboxAgent` resource. It carries the same spec as a regular `Agent`, but the kagent controller runs it as a sandboxed workload on the runtime instead of a plain Deployment.
+
+### AgentHarness
 
 Set the harness runtime to `substrate` and provide the substrate configuration. The key fields are:
 

--- a/src/app/docs/kagent/concepts/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/concepts/agent-substrate/page.mdx
@@ -1,0 +1,72 @@
+---
+title: "Agent Substrate"
+pageOrder: 5
+description: "Run declarative agents on Agent Substrate — a Kubernetes-native runtime that delivers fast startup, efficient resource usage, and secure sandboxed execution."
+---
+
+export const metadata = {
+  title: "Agent Substrate",
+  description: "Run declarative agents on Agent Substrate — a Kubernetes-native runtime that delivers fast startup, efficient resource usage, and secure sandboxed execution.",
+  author: "kagent.dev"
+};
+
+# Agent Substrate
+
+Agent Substrate is a Kubernetes-native runtime for running AI agents and other stateful workloads efficiently. Instead of dedicating one pod per agent — which wastes capacity while agents sit idle — Substrate decouples an agent's lifecycle from pod infrastructure. Idle agents are snapshotted to object storage and rehydrated on demand, so a small pool of pre-warmed workers can host far more agents than there are pods.
+
+kagent can run a declarative agent directly on Agent Substrate by selecting it as the [`AgentHarness`](/docs/kagent/concepts/agent-harness) runtime. When `runtime` is set to `substrate`, kagent generates a per-harness `ActorTemplate` and creates an `Actor` from it, referencing a `WorkerPool` for capacity.
+
+## Why Agent Substrate
+
+- **Fast startup** — Agents cold-start by restoring a compressed snapshot rather than booting a fresh pod, so they resume in a fraction of the time.
+- **Efficient resource usage** — A pool of pre-warmed workers multiplexes many actors across far fewer pods, persisting idle actors to object storage instead of holding a pod each.
+- **Secure execution** — Each workload runs inside a gVisor sandbox, isolating untrusted agent code from the host and from other actors.
+- **Declarative management** — WorkerPools and ActorTemplates are Kubernetes CRDs, so the runtime is configured and versioned with the same GitOps workflow as the rest of your platform.
+
+## Core concepts
+
+| Term | Definition |
+| --- | --- |
+| **Actor** | An individual agent instance with isolated state, managed by Substrate. |
+| **WorkerPool** | A CRD declaring the pool of pre-warmed gVisor worker pods that host actors. |
+| **ActorTemplate** | A CRD defining an actor's configuration and lifecycle behavior. kagent generates one per `AgentHarness`. |
+| **Snapshot** | A compressed (Zstd) checkpoint of actor state in object storage that enables suspension and fast restoration. |
+| **Session** | The execution context that tracks an actor's activity and checkpoints. |
+
+## How it works
+
+When an agent is invoked, Substrate restores its actor onto an available worker from the WorkerPool — rehydrating from a snapshot if the actor was idle. The agent runs inside a gVisor sandbox for the duration of the session. When the actor goes idle, its state is checkpointed back to object storage and the worker is freed to host another actor. This snapshot-and-restore cycle is what lets a single worker pool serve many more agents than a pod-per-agent model.
+
+## Architecture
+
+Agent Substrate is composed of a control plane, a data plane, and snapshot storage:
+
+**Control plane**
+
+- `ateapi` — gRPC API and workflow engine, backed by Redis.
+- `atecontroller` — the Kubernetes reconciler for `WorkerPool` and `ActorTemplate` resources.
+
+**Data plane**
+
+- `atenet` — an L7 proxy and DNS routing layer that directs traffic to actors.
+- `atelet` — a DaemonSet that manages snapshot uploads and downloads on each node.
+- `ateom` — the worker-pod supervisor that communicates with the gVisor runtime.
+
+**Storage**
+
+- Zstd-compressed checkpoint snapshots stored in object storage (GCS or S3).
+
+## Using Agent Substrate with an AgentHarness
+
+Set the harness runtime to `substrate` and provide the substrate configuration. The key fields are:
+
+- `workerPoolRef` — references an existing WorkerPool in the harness namespace. When unset, the controller uses its configured default WorkerPool.
+- `snapshotsConfig` — configures where actor memory snapshots are stored. Defaults to `gs://ate-snapshots/<namespace>/<agentharnessname>` when unset.
+- `workloadImage` — overrides the default NemoClaw/OpenClaw sandbox image used in the generated ActorTemplate.
+- `gatewayTokenSecretRef` — references a Secret (with a `token` key) holding the OpenClaw gateway Bearer token. Prefer this over an inline `gatewayToken` for production secrets.
+
+See the [API reference](/docs/kagent/resources/api-ref) for the full `AgentHarnessSubstrateSpec` schema.
+
+## Learn more
+
+For a deeper dive into the runtime internals, see the [Agent Substrate documentation](https://learn.agentsubstrate.dev/).

--- a/src/app/docs/kagent/concepts/page.mdx
+++ b/src/app/docs/kagent/concepts/page.mdx
@@ -25,6 +25,7 @@ import QuickLink from '@/components/quick-link';
     <QuickLink title="Agents" description="Learn about AI agents." href="/docs/kagent/concepts/agents" />
     <QuickLink title="Tools" description="Learn about tools and MCP." href="/docs/kagent/concepts/tools" />
     <QuickLink title="Agent Harness" description="Understand OpenShell-backed execution environments and backend-specific channel configuration." href="/docs/kagent/concepts/agent-harness" />
+    <QuickLink title="Agent Substrate" description="Run declarative agents on a Kubernetes-native runtime with fast startup, efficient resource usage, and secure gVisor-sandboxed execution." href="/docs/kagent/concepts/agent-substrate" />
     <QuickLink title="Tools Ecosystem" description="Comprehensive catalog of built-in tools for Kubernetes, Helm, Istio, Prometheus, Grafana, Cilium, and Argo Rollouts." href="/docs/kagent/resources/tools-ecosystem" />
     <QuickLink title="Human-in-the-Loop" description="Configure tool approval gates and interactive user prompts for agent oversight." href="/docs/kagent/examples/human-in-the-loop" />
     <QuickLink title="Agent Memory" description="Enable vector-backed long-term memory for agents to learn from past interactions." href="/docs/kagent/concepts/agent-memory" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -407,6 +407,7 @@
 .rd-float-b { right: 8%; bottom: -22px; }
 .rd-float-b2 { left: 8%; bottom: -22px; }
 .rd-float-t { right: -24px; top: 50%; }
+.rd-float-l2 { left: -24px; bottom: 12%; }
 
 /* ---- Logo strip ---- */
 .rd-logo-strip {
@@ -953,7 +954,7 @@
 @media (max-width: 980px) {
   .rd-value-grid, .rd-uc-grid, .rd-comm-grid, .rd-ed-grid, .rd-std-grid { grid-template-columns: 1fr; }
   .rd-how-grid { grid-template-columns: 1fr; }
-  .rd-float-l, .rd-float-r, .rd-float-b2, .rd-float-t { display: none; }
+  .rd-float-l, .rd-float-r, .rd-float-b2, .rd-float-t, .rd-float-l2 { display: none; }
   .rd-qs-bar { flex-wrap: wrap; height: auto; padding: 10px 16px; gap: 8px; }
   .rd-qs-tabs { flex-wrap: wrap; }
   .rd-qs-body code { font-size: 12.5px; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -352,6 +352,16 @@ export default function RedesignPage() {
                   <div className="rd-chip-sub">LangGraph · CrewAI · Google ADK</div>
                 </div>
               </div>
+
+              <div className="rd-float-chip rd-float-l2">
+                <div className="rd-chip-icon" style={{ background: '#EEE8FF', color: '#7C3AED' }}>
+                  <Icon name="bolt" size={20} />
+                </div>
+                <div>
+                  <div className="rd-chip-label">Agent Substrate</div>
+                  <div className="rd-chip-sub">Fast startup · Secure · Efficient</div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -372,6 +382,7 @@ export default function RedesignPage() {
               ['eye', 'Observable by default', 'OpenTelemetry traces, Prometheus metrics, structured logs. See every prompt, every tool call, every token.'],
               ['shield', 'Zero-trust ready', 'Run on top of Istio or Ambient Mesh. mTLS, fine-grained RBAC, and policy-driven egress for agent traffic.'],
               ['shield', 'NVIDIA NemoClaw', 'Built-in security and privacy guardrails via NVIDIA NemoClaw. Run Nemotron locally or route to cloud models — with policy enforcement on every call.'],
+              ['bolt', 'Agent Substrate', 'Run declarative agents on Agent Substrate for fast startup, efficient resource usage, and secure sandboxed execution — a Kubernetes-native runtime for agents at scale.'],
               ['book', 'Standards-based', 'Native MCP, A2A, OpenTelemetry, and Kubernetes APIs. No proprietary glue, no rewrite tax later.'],
             ].map(([icon, title, body], i) => (
               <div key={i} className="rd-value-card rv">
@@ -393,6 +404,7 @@ export default function RedesignPage() {
               {[
                 ['Agent lifecycle via CRDs', 'Define, version, and roll out agents with kubectl and GitOps — the same workflow as every other workload.'],
                 ['Multi-runtime support', 'Go and Python ADK runtimes. Pick the language that fits, or mix both in the same cluster.'],
+                ['Agent Substrate runtime', 'Run agents on the substrate runtime — a WorkerPool + Actor model that delivers fast cold starts, low resource overhead, and secure isolation per agent.'],
                 ['BYO frameworks', 'LangGraph, CrewAI, Google ADK, or your own — bring any agent framework and kagent orchestrates it.'],
                 ['Long-term memory', 'Persistent vector-backed memory across sessions. Agents remember context, not just the last prompt.'],
                 ['Human-in-the-loop', 'Tool approval gates, agent-initiated questions, and cascading HITL — humans stay in control.'],
@@ -634,7 +646,7 @@ export default function RedesignPage() {
           <div className="rd-comm-grid">
             <div className="rd-comm-card rv">
               <div className="rd-c-icon"><Icon name="git" /></div>
-              <div className="rd-stat">2,500+</div>
+              <div className="rd-stat">3,000+</div>
               <div className="rd-stat-l">GITHUB STARS</div>
               <h4>Open source</h4>
               <p>Apache 2.0. Public roadmap, public RFCs, public weekly community calls.</p>

--- a/src/config/navigation.json
+++ b/src/config/navigation.json
@@ -95,6 +95,11 @@
             "description": "Understand AgentHarness resources, OpenShell-backed execution environments, and backend-specific channel configuration."
           },
           {
+            "title": "Agent Substrate",
+            "href": "/docs/kagent/concepts/agent-substrate",
+            "description": "Run declarative agents on Agent Substrate — a Kubernetes-native runtime that delivers fast startup, efficient resource usage, and secure sandboxed execution."
+          },
+          {
             "title": "Agent Memory",
             "href": "/docs/kagent/concepts/agent-memory",
             "description": "Enable vector-backed long-term memory for agents to learn from past interactions."


### PR DESCRIPTION
## Summary
Adds **Agent Substrate** (new in kagent v0.9.7) across the site, plus a small stats refresh.

### Homepage (`src/app/page.tsx`, `src/app/globals.css`)
- New **Agent Substrate** card in the *Why kagent* grid (benefit: fast startup, efficient resources, secure execution)
- New **Agent Substrate runtime** item in *Platform capabilities*
- New Agent Substrate floating chip in the hero (`.rd-float-l2`), hidden on mobile like the other side chips
- Bumped **GitHub stars** stat from 2,500+ to **3,000+**

### Docs — Core Concepts (`src/app/docs/kagent/concepts/`)
- New page **`agent-substrate/page.mdx`**: what it is, why it matters, core concept table (Actor, WorkerPool, ActorTemplate, Snapshot, Session), how snapshot-and-restore works, control/data-plane architecture, and how to use it via `AgentHarness` `runtime: substrate`
- QuickLink added to the concepts index; Agent Memory reordered after it
- Regenerated `navigation.json` / `sitemap.xml`

## Verification
- `check-links`: 454 links, no broken links
- Homepage and `/docs/kagent/concepts/agent-substrate` render locally (HTTP 200)

Sources: in-repo API reference (`AgentHarnessSubstrateSpec`) and https://learn.agentsubstrate.dev/

🤖 Generated with [Claude Code](https://claude.com/claude-code)