### PR TITLE
fix(docs): correct AgentHarness OpenShell install steps

### DIFF
--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -208,7 +208,8 @@ Review the following advanced configuration options that you might want to set u
    kubectl -n openshell create secret generic openshell-ssh-handshake \
        --from-literal=secret="$(openssl rand -hex 32)"
 
-   kubectl apply -f https://raw.githubusercontent.com/NVIDIA/OpenShell/refs/heads/main/deploy/kube/manifests/agent-sandbox.yaml
+   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
+
 
    helm upgrade --install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
    --version 0.0.49 \
@@ -216,11 +217,11 @@ Review the following advanced configuration options that you might want to set u
    --create-namespace \
    --values - <<'EOF'
    server:
-   disableTls: true
+      disableTls: true
    auth:
       allowUnauthenticatedUsers: true
    service:
-   metricsPort: 0
+      metricsPort: 0
    EOF
    
    This example disables TLS and authentication. For production environments, configure TLS and authentication according to your OpenShell requirements.


### PR DESCRIPTION
Fixes incorrect AgentHarness OpenShell install instructions: the guide pointed at a vendored agent-sandbox manifest and used invalid Helm values YAML, which could break OpenShell setup when users followed the installation page.

Closes: #388 