### PR TITLE
Telegram doc fix

### DIFF
--- a/src/app/docs/kagent/examples/telegram-bot/page.mdx
+++ b/src/app/docs/kagent/examples/telegram-bot/page.mdx
@@ -98,6 +98,10 @@ spec:
           - helm_get_release
           - prometheus_query_tool
           - datetime_get_current_time
+          - k8s_delete_resource
+          - k8s_apply_manifest
+          - helm_upgrade
+          - helm_uninstall
           requireApproval:
           - k8s_delete_resource
           - k8s_apply_manifest

--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -208,7 +208,8 @@ Review the following advanced configuration options that you might want to set u
    kubectl -n openshell create secret generic openshell-ssh-handshake \
        --from-literal=secret="$(openssl rand -hex 32)"
 
-   kubectl apply -f https://raw.githubusercontent.com/NVIDIA/OpenShell/refs/heads/main/deploy/kube/manifests/agent-sandbox.yaml
+   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
+
 
    helm upgrade --install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
    --version 0.0.49 \
@@ -216,11 +217,11 @@ Review the following advanced configuration options that you might want to set u
    --create-namespace \
    --values - <<'EOF'
    server:
-   disableTls: true
+      disableTls: true
    auth:
       allowUnauthenticatedUsers: true
    service:
-   metricsPort: 0
+      metricsPort: 0
    EOF
    
    This example disables TLS and authentication. For production environments, configure TLS and authentication according to your OpenShell requirements.


### PR DESCRIPTION
Fixes incorrect telegram-bot agent example: destructive tools were listed only under `requireApproval` and missing from `toolNames`, which violates the Agent CRD and would fail when users applied the manifest.

Closes: #391 