### PR TITLE
doc fixes for substrate version

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ import createMDX from "@next/mdx";
 import rehypeUnwrapImages from 'rehype-unwrap-images'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
+import { remarkVersionSubstitution } from './scripts/remark-version-substitution.mjs'
 
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
@@ -41,7 +42,7 @@ const nextConfig = {
 
 const withMDX = createMDX({
   options: {
-    remarkPlugins: [remarkFrontmatter, remarkGfm],
+    remarkPlugins: [remarkFrontmatter, remarkGfm, remarkVersionSubstitution],
     rehypePlugins: [rehypeUnwrapImages],
   },
 })

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rehype-unwrap-images": "^1.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
+    "unist-util-visit": "^5.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,840 +2,847 @@
     
     <url>
         <loc>https://kagent.dev/agents</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/blog</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/community</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-harness</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-memory</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-substrate</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agents</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/architecture</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/tools</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-agents</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-byo</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-harness</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-sandbox</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-substrate</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    
+    <url>
+        <loc>https://kagent.dev/docs/kagent/examples/agentgateway</loc>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agents-mcp</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/crewai-byo</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/discord-a2a</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/documentation</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/human-in-the-loop</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/langchain-byo</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/skills</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/slack-a2a</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/telegram-bot</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-mcp-tool</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/local-development</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/quickstart</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/system-prompts</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/features</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/installation</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/what-is-kagent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/audit-prompts</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/launch-ui</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/tracing</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/debug</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/operational-considerations</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/uninstall</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/upgrade</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/api-ref</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-add-mcp</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-bug-report</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-build</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-completion</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-dashboard</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-deploy</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-get</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-help</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-init</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-install</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-invoke</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-mcp</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-run</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-uninstall</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-version</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/faq</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/helm</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/release-notes</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/tools-ecosystem</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/amazon-bedrock</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/anthropic</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/azure-openai</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/byo-openai</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/gemini</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/google-vertexai</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/ollama</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/openai</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/sap-ai-core</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/xai</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/install-controller</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/server</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/fastmcp-python</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/mcp-go</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/introduction</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/quickstart</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/api-ref</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-add-tool</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-build</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-completion</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-deploy</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-help</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-init</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-install</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-run</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-secrets</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/secrets</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/enterprise</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/page.tsx</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/argo-rollouts-conversion-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/cilium-crd-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/helm-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/istio-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/k8s-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/kgateway-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/observability-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/promql-agent</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/istio</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/kubernetes</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/prometheus</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/documentation</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/helm</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/argo</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/grafana</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/other</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/cilium</loc>
-        <lastmod>2026-06-12</lastmod>
+        <lastmod>2026-06-18</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/scripts/remark-version-substitution.mjs
+++ b/scripts/remark-version-substitution.mjs
@@ -1,0 +1,33 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { visit } from "unist-util-visit";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const jiti = require("jiti")(join(__dirname, ".."));
+const { VERSIONS } = jiti(join(__dirname, "../src/app/docs/_constants.ts"));
+
+const VERSION_PATTERN = /\{VERSIONS\.(\w+)\}/g;
+
+function substituteVersions(value) {
+  return value.replace(VERSION_PATTERN, (match, key) => {
+    if (Object.hasOwn(VERSIONS, key)) {
+      return VERSIONS[key];
+    }
+
+    return match;
+  });
+}
+
+/**
+ * Replace {VERSIONS.key} placeholders inside fenced and inline code blocks.
+ * MDX evaluates the same syntax in prose, but treats code fences as literal text.
+ */
+export function remarkVersionSubstitution() {
+  return (tree) => {
+    visit(tree, "code", (node) => {
+      node.value = substituteVersions(node.value);
+    });
+  };
+}

--- a/src/app/docs/_constants.ts
+++ b/src/app/docs/_constants.ts
@@ -6,6 +6,7 @@
 export const VERSIONS = {
   // Core kagent version requirements
   kagent: "0.9.1",
+  kagentSubstrate: "0.9.7",
   kmcp: "0.2.8",
 
   // External dependencies

--- a/src/app/docs/_constants.ts
+++ b/src/app/docs/_constants.ts
@@ -5,9 +5,8 @@
 
 export const VERSIONS = {
   // Core kagent version requirements
-  kagent: "0.9.1",
-  kagentSubstrate: "0.9.7",
-  kmcp: "0.2.8",
+  kagent: "0.9.9",
+  kmcp: "0.3.0",
 
   // External dependencies
   agentSandbox: "0.3.10",

--- a/src/app/docs/kagent/examples/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/examples/agent-substrate/page.mdx
@@ -14,19 +14,19 @@ export const metadata = {
 
 # Agent Substrate
 
-This example walks from an empty machine to a declarative agent running inside a gVisor actor on [Agent Substrate](/docs/kagent/concepts/agent-substrate). Everything pulls from published OCI charts — no source builds, no repo clones.
+In this guide, you install Agent Substrate and kagent on a local kind cluster, then deploy a declarative `SandboxAgent` that runs inside a gVisor actor. All components come from published OCI charts — no source builds or repo clones required.
 
-By the end you'll have:
+By the end, you will have:
 
-- A kind cluster running Agent Substrate {VERSIONS.agentSubstrate} in `ate-system`.
-- kagent 0.9.7 or later installed with the substrate integration enabled. **kagent 0.9.7 is the minimum version** — earlier releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
+- Agent Substrate v{VERSIONS.agentSubstrate} running in the `ate-system` namespace.
+- kagent v{VERSIONS.kagentSubstrate} or later installed with the substrate integration enabled. **kagent v{VERSIONS.kagentSubstrate} is the minimum version** — earlier releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
 - A `SandboxAgent` running on substrate, reachable from the kagent UI.
 
 For background on what substrate is and how it differs from a per-pod agent runtime, see the [Agent Substrate concept page](/docs/kagent/concepts/agent-substrate). This guide does not cover the `AgentHarness` path on substrate.
 
 ## Before you begin
 
-You will need:
+You need:
 
 - `kind`, `kubectl`, and `helm` on your `PATH`.
 - A running Docker daemon (Docker Desktop or equivalent).
@@ -42,7 +42,7 @@ export OPENAI_API_KEY="sk-..."
 kind create cluster --name kagent-substrate
 ```
 
-The substrate {VERSIONS.agentSubstrate} chart defaults to JWT auth backed by Kubernetes ServiceAccount tokens, so a vanilla kind cluster works — no feature gates or custom kind config are required.
+The substrate v{VERSIONS.agentSubstrate} chart defaults to JWT auth backed by Kubernetes ServiceAccount tokens, so a vanilla kind cluster works — no feature gates or custom kind config are required.
 
 ## Step 2: Install Agent Substrate
 
@@ -70,27 +70,31 @@ You should see `ate-api-server`, `ate-controller`, `atelet-*`, `atenet-router`, 
 
 ## Step 3: Install kagent with substrate enabled
 
-> Pin the chart to `0.9.7` or later. The `controller.substrate.*` and `substrateWorkerPool.*` values used below were introduced in 0.9.7; against an older chart they will be silently ignored and the controller will start without the substrate integration.
+<Aside type="warning">
+Pin the chart to v{VERSIONS.kagentSubstrate} or later. The `controller.substrate.*` and `substrateWorkerPool.*` values used below were introduced in v{VERSIONS.kagentSubstrate}; against an older chart they are silently ignored and the controller starts without the substrate integration.
+</Aside>
 
-Confirm the OpenAI key is set in this shell before running helm. If it's empty, the install will run silently with no `kagent-openai` Secret and the default agent pods will land in `CreateContainerConfigError`.
+Confirm the OpenAI key is set in this shell before you run Helm. If the key is empty, the install runs silently with no `kagent-openai` Secret and the default agent pods land in `CreateContainerConfigError`.
 
 ```bash
 [[ -n "${OPENAI_API_KEY:-}" ]] && echo "key is set (len=${#OPENAI_API_KEY})" || echo "OPENAI_API_KEY is empty — export it first"
 ```
 
-> Don't combine the export and the helm command on one line — `OPENAI_API_KEY="$(cat ...)" helm ... --set providers.openAI.apiKey="${OPENAI_API_KEY}"` evaluates `${OPENAI_API_KEY}` before the inline assignment runs and passes an empty string. Either `export` on its own line first, or splice the value directly with `--set providers.openAI.apiKey="$(cat ~/path/to/key)"`.
+<Aside type="tip">
+Do not combine the export and the Helm command on one line — `OPENAI_API_KEY="$(cat ...)" helm ... --set providers.openAI.apiKey="${OPENAI_API_KEY}"` evaluates `${OPENAI_API_KEY}` before the inline assignment runs and passes an empty string. Either `export` on its own line first, or splice the value directly with `--set providers.openAI.apiKey="$(cat ~/path/to/key)"`.
+</Aside>
 
 Install the CRDs, then kagent with the substrate flags.
 
 ```bash
 helm upgrade --install kagent-crds \
   oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
-  --version 0.9.7 \
+  --version {VERSIONS.kagentSubstrate} \
   --namespace kagent --create-namespace --wait
 
 helm upgrade --install kagent \
   oci://ghcr.io/kagent-dev/kagent/helm/kagent \
-  --version 0.9.7 \
+  --version {VERSIONS.kagentSubstrate} \
   --namespace kagent --timeout 10m --wait \
   --set providers.openAI.apiKey="${OPENAI_API_KEY}" \
   --set providers.default=openAI \
@@ -102,9 +106,9 @@ helm upgrade --install kagent \
   --set substrateWorkerPool.ateomImage=ghcr.io/kagent-dev/substrate/ateom-gvisor:v{VERSIONS.agentSubstrate}
 ```
 
-The `controller.substrate.*` and `substrateWorkerPool.*` flags are what turn on the substrate integration. The rest is a standard kagent install.
+The `controller.substrate.*` and `substrateWorkerPool.*` flags turn on the substrate integration. The rest is a standard kagent install.
 
-If helm hits its `--timeout 10m` while waiting on the cold-start pod startup race (the controller restarts a couple of times waiting on postgres), wait for the controller manually and continue.
+If Helm hits its `--timeout 10m` while waiting on the cold-start pod startup race (the controller restarts a couple of times waiting on postgres), wait for the controller manually and continue.
 
 ```bash
 kubectl wait deploy/kagent-controller -n kagent --for=condition=Available --timeout=10m
@@ -117,16 +121,16 @@ kubectl get secret kagent-openai -n kagent         # should exist with 1 data en
 kubectl get pods -n kagent | grep -v Running       # only header + Completed jobs expected
 ```
 
-If you see `CreateContainerConfigError` on the default agent pods, the secret didn't get created — re-run the kagent helm command with `--reuse-values --set providers.openAI.apiKey="$(cat ~/path/to/key)"` to patch it in. The deployments will roll to new pods automatically.
+If you see `CreateContainerConfigError` on the default agent pods, the secret did not get created — re-run the kagent Helm command with `--reuse-values --set providers.openAI.apiKey="$(cat ~/path/to/key)"` to patch it in. The deployments roll to new pods automatically.
 
-### Tuning the WorkerPool size
+### Tune the WorkerPool size
 
-`substrateWorkerPool.replicas=1` is the chart default. One worker is enough for a declarative-only walkthrough: session actors release their slot the moment they snapshot back to object storage, so a single worker can serve many sequential sessions. Bump it when:
+`substrateWorkerPool.replicas=1` is the chart default. One worker is enough for a declarative-only walkthrough: session actors release their slot the moment they snapshot back to object storage, so a single worker can serve many sequential sessions. Increase the replica count when:
 
 - You add a long-lived `AgentHarness`. The `ahr-<...>` actor pins a slot for the lifetime of the CR, so you need at least `1 + (number of harnesses)`.
 - You want simultaneous, overlapping declarative sessions.
 
-You can change the size three ways, depending on how permanent you want it.
+You can change the size three ways, depending on how permanent you want the change.
 
 ```bash
 # 1) Quick, ephemeral — scale the live CR. Reverts on the next helm upgrade.
@@ -134,7 +138,7 @@ kubectl scale workerpool kagent-default -n kagent --replicas=3
 
 # 2) Stick it into the helm release — survives upgrades.
 helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
-  --version 0.9.7 --namespace kagent --reuse-values \
+  --version {VERSIONS.kagentSubstrate} --namespace kagent --reuse-values \
   --set substrateWorkerPool.replicas=3
 
 # 3) Fresh install — change the value on the Step 3 install command above.
@@ -159,7 +163,7 @@ A `SandboxAgent` with `platform: substrate` and a `substrate.workerPoolRef` runs
    - **Name**: `hello-substrate`
    - **Namespace**: `kagent`
    - **Model config**: `default-model-config`
-   - **Runtime**: `Go` (required — the Python ADK isn't supported on substrate today)
+   - **Runtime**: `Go` (required — the Python ADK is not supported on substrate today)
    - **System message**:
      ```
      You are a friendly assistant living inside an Agent Substrate sandbox.
@@ -211,7 +215,7 @@ Expected reply:
 
 > *I am hello-substrate, a Go ADK declarative agent running inside a gVisor actor.*
 
-Behind the scenes, a per-session gVisor actor was restored from the golden snapshot, ran the LLM call, and snapshotted itself back to object storage. Open **View → Substrate** to see the actor in the inventory — between requests it will sit `Suspended`.
+Behind the scenes, a per-session gVisor actor was restored from the golden snapshot, ran the LLM call, and snapshotted itself back to object storage. Open **View → Substrate** to see the actor in the inventory — between requests it sits `Suspended`.
 
 ## Cleanup
 

--- a/src/app/docs/kagent/examples/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/examples/agent-substrate/page.mdx
@@ -19,7 +19,7 @@ In this guide, you install Agent Substrate and kagent on a local kind cluster, t
 By the end, you will have:
 
 - Agent Substrate v{VERSIONS.agentSubstrate} running in the `ate-system` namespace.
-- kagent v{VERSIONS.kagentSubstrate} or later installed with the substrate integration enabled. **kagent v{VERSIONS.kagentSubstrate} is the minimum version** — earlier releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
+- kagent v{VERSIONS.kagent} or later installed with the substrate integration enabled. **kagent v{VERSIONS.kagent} is the minimum version** — earlier releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
 - A `SandboxAgent` running on substrate, reachable from the kagent UI.
 
 For background on what substrate is and how it differs from a per-pod agent runtime, see the [Agent Substrate concept page](/docs/kagent/concepts/agent-substrate). This guide does not cover the `AgentHarness` path on substrate.
@@ -71,7 +71,7 @@ You should see `ate-api-server`, `ate-controller`, `atelet-*`, `atenet-router`, 
 ## Step 3: Install kagent with substrate enabled
 
 <Aside type="warning">
-Pin the chart to v{VERSIONS.kagentSubstrate} or later. The `controller.substrate.*` and `substrateWorkerPool.*` values used below were introduced in v{VERSIONS.kagentSubstrate}; against an older chart they are silently ignored and the controller starts without the substrate integration.
+Pin the chart to v{VERSIONS.kagent} or later. The `controller.substrate.*` and `substrateWorkerPool.*` values used below were introduced in v{VERSIONS.kagent}; against an older chart they are silently ignored and the controller starts without the substrate integration.
 </Aside>
 
 Confirm the OpenAI key is set in this shell before you run Helm. If the key is empty, the install runs silently with no `kagent-openai` Secret and the default agent pods land in `CreateContainerConfigError`.
@@ -89,12 +89,12 @@ Install the CRDs, then kagent with the substrate flags.
 ```bash
 helm upgrade --install kagent-crds \
   oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
-  --version {VERSIONS.kagentSubstrate} \
+  --version {VERSIONS.kagent} \
   --namespace kagent --create-namespace --wait
 
 helm upgrade --install kagent \
   oci://ghcr.io/kagent-dev/kagent/helm/kagent \
-  --version {VERSIONS.kagentSubstrate} \
+  --version {VERSIONS.kagent} \
   --namespace kagent --timeout 10m --wait \
   --set providers.openAI.apiKey="${OPENAI_API_KEY}" \
   --set providers.default=openAI \
@@ -138,7 +138,7 @@ kubectl scale workerpool kagent-default -n kagent --replicas=3
 
 # 2) Stick it into the helm release — survives upgrades.
 helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
-  --version {VERSIONS.kagentSubstrate} --namespace kagent --reuse-values \
+  --version {VERSIONS.kagent} --namespace kagent --reuse-values \
   --set substrateWorkerPool.replicas=3
 
 # 3) Fresh install — change the value on the Step 3 install command above.


### PR DESCRIPTION
- fix version reuse within codeblocks (see following screenshots)
- bump versions
- style review

BEFORE - the version was not rendering within codeblocks:
<img width="996" height="385" alt="image" src="https://github.com/user-attachments/assets/40501145-a56c-4a80-9535-644f00a276b0" />

AFTER - 
<img width="954" height="374" alt="image" src="https://github.com/user-attachments/assets/69d3fe7e-565a-464e-b171-47680d342dc5" />
