### PR TITLE
docs/restore pin version

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,847 +2,847 @@
     
     <url>
         <loc>https://kagent.dev/agents</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/blog</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/community</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-harness</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-memory</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agent-substrate</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/agents</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/architecture</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/concepts/tools</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-agents</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/a2a-byo</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-harness</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-sandbox</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agent-substrate</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agentgateway</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/agents-mcp</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/crewai-byo</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/discord-a2a</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/documentation</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/human-in-the-loop</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/langchain-byo</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/skills</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/slack-a2a</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/examples/telegram-bot</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/first-mcp-tool</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/local-development</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/quickstart</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/getting-started/system-prompts</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/features</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/installation</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/introduction/what-is-kagent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/audit-prompts</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/launch-ui</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/observability/tracing</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/debug</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/operational-considerations</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/uninstall</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/operations/upgrade</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/api-ref</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-add-mcp</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-bug-report</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-build</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-completion</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-dashboard</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-deploy</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-get</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-help</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-init</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-install</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-invoke</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-mcp</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-run</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-uninstall</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli/kagent-version</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/cli</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/faq</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/helm</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/release-notes</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/resources/tools-ecosystem</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/amazon-bedrock</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/anthropic</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/azure-openai</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/byo-openai</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/gemini</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/google-vertexai</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/ollama</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/openai</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/sap-ai-core</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kagent/supported-providers/xai</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/install-controller</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/deploy/server</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/fastmcp-python</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop/mcp-go</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/develop</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/introduction</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/quickstart</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/api-ref</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-add-tool</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-build</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-completion</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-deploy</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-help</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-init</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-install</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-run</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference/kmcp-secrets</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/reference</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs/kmcp/secrets</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/docs</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/enterprise</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/page.tsx</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/argo-rollouts-conversion-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/cilium-crd-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/helm-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/istio-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/k8s-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/kgateway-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/observability-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/agents/promql-agent</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/istio</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/kubernetes</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/prometheus</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/documentation</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/helm</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/argo</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/grafana</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/other</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     
     <url>
         <loc>https://kagent.dev/tools/cilium</loc>
-        <lastmod>2026-06-18</lastmod>
+        <lastmod>2026-06-22</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/src/app/docs/kagent/examples/agent-harness/page.mdx
+++ b/src/app/docs/kagent/examples/agent-harness/page.mdx
@@ -20,7 +20,7 @@ Use `AgentHarness` when you want kagent to manage the lifecycle of an OpenClaw, 
 
 ## Before you begin
 
-1. Install kagent v{VERSIONS.kagent} or later by following the [quick start](/docs/kagent/getting-started/quickstart) guide.
+1. Install kagent v0.9.2 or later by following the [quick start](/docs/kagent/getting-started/quickstart) guide.
 2. Install and expose an OpenShell gateway that the kagent controller can reach over gRPC. For Helm-based setup instructions, see [Enable AgentHarness support](/docs/kagent/introduction/installation#enable-agentharness-support).
 3. Configure the kagent controller with the gateway address. For example, set the controller environment variable `OPENSHELL_GATEWAY_URL` to a gRPC target such as `dns:///openshell.openshell.svc:443`.
 

--- a/src/app/docs/kagent/examples/agent-sandbox/page.mdx
+++ b/src/app/docs/kagent/examples/agent-sandbox/page.mdx
@@ -34,7 +34,7 @@ The default runtime settings are:
 
 ## Before you begin
 
-1. Install kagent v{VERSIONS.kagent} or later by following the [quick start](/docs/kagent/getting-started/quickstart) guide.
+1. Install kagent v0.9.0 or later by following the [quick start](/docs/kagent/getting-started/quickstart) guide.
 
 2. Install the agent-sandbox controller and CRDs. The example uses version {VERSIONS.agentSandbox}.
 

--- a/src/app/docs/kagent/examples/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/examples/agent-substrate/page.mdx
@@ -19,7 +19,7 @@ In this guide, you install Agent Substrate and kagent on a local kind cluster, t
 By the end, you will have:
 
 - Agent Substrate v{VERSIONS.agentSubstrate} running in the `ate-system` namespace.
-- kagent v{VERSIONS.kagent} or later installed with the substrate integration enabled. **kagent v{VERSIONS.kagent} is the minimum version** — earlier releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
+- kagent v0.9.7 or later installed with the substrate integration enabled. Earlier kagent releases do not include the controller wiring that lets a `SandboxAgent` target substrate.
 - A `SandboxAgent` running on substrate, reachable from the kagent UI.
 
 For background on what substrate is and how it differs from a per-pod agent runtime, see the [Agent Substrate concept page](/docs/kagent/concepts/agent-substrate). This guide does not cover the `AgentHarness` path on substrate.
@@ -71,7 +71,7 @@ You should see `ate-api-server`, `ate-controller`, `atelet-*`, `atenet-router`, 
 ## Step 3: Install kagent with substrate enabled
 
 <Aside type="warning">
-Pin the chart to v{VERSIONS.kagent} or later. The `controller.substrate.*` and `substrateWorkerPool.*` values used below were introduced in v{VERSIONS.kagent}; against an older chart they are silently ignored and the controller starts without the substrate integration.
+Pin the chart to v0.9.7 or later. Earlier versions do not include the `controller.substrate.*` and `substrateWorkerPool.*` values; against an older chart they are silently ignored and the controller starts without the substrate integration.
 </Aside>
 
 Confirm the OpenAI key is set in this shell before you run Helm. If the key is empty, the install runs silently with no `kagent-openai` Secret and the default agent pods land in `CreateContainerConfigError`.

--- a/src/app/docs/kagent/getting-started/quickstart/page.mdx
+++ b/src/app/docs/kagent/getting-started/quickstart/page.mdx
@@ -4,6 +4,8 @@ pageOrder: 1
 description: "A quick guide to get kagent installed and running with your first AI agent."
 ---
 
+import { VERSIONS } from "../../../_constants";
+
 export const metadata = {
   title: "kagent quick start",
   description: "Get started with this guide and get kagent installed and run your first AI agent.",
@@ -32,7 +34,7 @@ To run the AI agents you'll also need an [OpenAI](https://openai.com) API key. Y
    export OPENAI_API_KEY="your-api-key-here"
    ```
 
-2. Download the kagent CLI.
+2. Download the kagent CLI. By default, the latest version {VERSIONS.kagent} of kagent is installed.
 
    ```bash
    brew install kagent

--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -4,6 +4,8 @@ pageOrder: 1
 description: "Learn how to install kagent"
 ---
 
+import { VERSIONS } from "../../../_constants";
+
 export const metadata = {
   title: "Installing kagent",
   description: "Learn how to install kagent.",
@@ -28,7 +30,7 @@ Install kagent by using the kagent CLI or Helm.
    export OPENAI_API_KEY="your-api-key-here"
    ```
 
-2. Download the kagent CLI.
+2. Download the kagent CLI. By default, the latest version {VERSIONS.kagent} of kagent is installed.
 
    ```bash
    brew install kagent

--- a/src/app/docs/kagent/resources/helm/page.mdx
+++ b/src/app/docs/kagent/resources/helm/page.mdx
@@ -32,7 +32,7 @@ A Helm chart for kagent, built with Google ADK
 | file://../tools/querydoc | querydoc |  |
 | https://oauth2-proxy.github.io/manifests | oauth2-proxy | ~7.0.0 |
 | oci://ghcr.io/kagent-dev/kmcp/helm | kmcp | `${KMCP_VERSION}` |
-| oci://ghcr.io/kagent-dev/substrate/helm | substrate | ${SUBSTRATE_VERSION} |
+| oci://ghcr.io/kagent-dev/substrate/helm | substrate | `${SUBSTRATE_VERSION}` |
 | oci://ghcr.io/kagent-dev/tools/helm | kagent-tools | 0.2.1 |
 
 ## Values


### PR DESCRIPTION
- version reuse did not keep the correct version that the feature was introduced in
- install and quickstarts did not say what version was being installed
- and fix build failure:
```
17:09:23.027
Error occurred prerendering page "/docs/kagent/resources/helm". Read more: https://nextjs.org/docs/messages/prerender-error
17:09:23.030
ReferenceError: SUBSTRATE_VERSION is not defined
```