### PR TITLE
[fix] codetick and codeblock formatting

### DIFF
--- a/src/components/mdx/code-block.tsx
+++ b/src/components/mdx/code-block.tsx
@@ -22,6 +22,17 @@ export function CodeBlock({ children, language = 'typescript', className }: Code
   };
 
   if (!language || !className) {
+    const content = typeof children === 'string' ? children : String(children);
+    // A fenced code block without a language (e.g. ASCII diagrams) has no
+    // className but spans multiple lines. Render it in a real <pre> so
+    // whitespace and newlines are preserved instead of collapsing to inline.
+    if (content.includes('\n')) {
+      return (
+        <pre className="overflow-x-auto p-4 text-sm rounded-lg bg-muted font-mono text-foreground whitespace-pre">
+          <code className="font-mono">{content.replace(/\n$/, '')}</code>
+        </pre>
+      );
+    }
     return <code className='font-mono text-foreground'>{children}</code>
   }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,17 @@ export default {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		typography: {
+  			DEFAULT: {
+  				css: {
+  					// The typography plugin wraps inline <code> in literal backtick
+  					// characters via ::before/::after. We render our own styled
+  					// <code>, so strip them.
+  					'code::before': { content: '""' },
+  					'code::after': { content: '""' }
+  				}
+  			}
   		}
   	}
   },


### PR DESCRIPTION
followup to rendering comments in https://github.com/kagent-dev/website/pull/411