### PR TITLE
fix(ci): stop PR previews from deploying to production

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,6 +24,20 @@ jobs:
       - name: Build the site
         run: npm run build:worker
 
+      # Derive a stable preview alias from the PR branch name. Cloudflare preview
+      # aliases must be a valid subdomain label (lowercase alphanumerics and
+      # hyphens), and `<alias>-<worker>` must stay under the 63-char DNS limit, so
+      # sanitize and cap the length.
+      - name: Compute preview alias from branch name
+        id: alias
+        run: |
+          alias=$(echo "${{ github.head_ref }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9-]/-/g; s/-\{2,\}/-/g; s/^-*//; s/-*$//' \
+            | cut -c1-40)
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+          echo "Preview alias: $alias"
+
       - name: Create website preview
         id: deploy
         uses: cloudflare/wrangler-action@v3.14.1
@@ -35,7 +49,11 @@ jobs:
           # runs were redeploying prod. `versions upload` keeps prod on the
           # currently-deployed version; production is deployed only by
           # production.yaml (on merge to main).
-          command: versions upload --minify
+          #
+          # --preview-alias gives a STABLE, branch-named preview URL
+          # (<alias>-<worker>.<subdomain>.workers.dev) that updates in place on
+          # each push, instead of a new per-version hostname every time.
+          command: versions upload --minify --preview-alias ${{ steps.alias.outputs.alias }}
 
       - name: Print website URL
         env:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -55,7 +55,12 @@ jobs:
           # each push, instead of a new per-version hostname every time.
           command: versions upload --minify --preview-alias ${{ steps.alias.outputs.alias }}
 
-      - name: Print website URL
+      - name: Print website URLs
         env:
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
-        run: echo $DEPLOYMENT_URL
+          # Per-version URL (changes each push) from the wrangler-action output;
+          # stable alias URL built from the branch alias + fixed worker/subdomain.
+          VERSION_URL: ${{ steps.deploy.outputs.deployment-url }}
+          ALIAS: ${{ steps.alias.outputs.alias }}
+        run: |
+          echo "Version Preview URL: ${VERSION_URL}"
+          echo "Version Preview Alias URL: https://${ALIAS}-kagent-website.solo-io.workers.dev"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -30,7 +30,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --minify
+          # Upload a new Worker version and get a preview URL WITHOUT shifting
+          # production traffic. `deploy` promotes the version to 100% live, so PR
+          # runs were redeploying prod. `versions upload` keeps prod on the
+          # currently-deployed version; production is deployed only by
+          # production.yaml (on merge to main).
+          command: versions upload --minify
 
       - name: Print website URL
         env:

--- a/src/app/docs/kagent/examples/slack-a2a/page.mdx
+++ b/src/app/docs/kagent/examples/slack-a2a/page.mdx
@@ -50,7 +50,7 @@ You'll be redirected to the app's basic information page. Next, we need to give 
 1. Click the OAuth & Permissions tab from the left sidebar.
 2. Scroll down to the "Scopes" section.
 3. Click "Add an OAuth Scope" in the "Bot Token Scopes" section.
-4. From the dropdown menu add the the following scopes (you can add more scopes if you want to experiment with other features):
+4. From the dropdown menu add the following scopes (you can add more scopes if you want to experiment with other features):
     - `chat:write`
     - `commands`
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,3 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 main = ".open-next/worker.js"
 assets = { directory = ".open-next/assets", binding = "ASSETS" }
+
+# Enable per-version preview URLs so PR builds (`wrangler versions upload` in
+# preview.yaml) get a shareable URL without deploying to production.
+preview_urls = true


### PR DESCRIPTION
The Deploy Preview workflow ran `wrangler deploy`, which promotes the new version to 100% live traffic, so every PR was redeploying production. Switch previews to `wrangler versions upload` (uploads an isolated version + preview URL, no traffic shift), add a dedicated Production workflow that deploys only on merge to main / manual dispatch, and enable preview_urls in wrangler.toml so uploaded versions get a shareable URL.