### PR TITLE
ci: add production deploy workflow

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,0 +1,45 @@
+name: Production
+
+# Deploys the site to PRODUCTION. `wrangler deploy` promotes the new version to
+# 100% live traffic. Runs on merge to main, or manually via the Actions tab. PR
+# builds use preview.yaml (`versions upload`) and never reach production.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Never run two production deploys at once; do not cancel an in-flight deploy.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the site
+        run: npm run build:worker
+
+      - name: Deploy to production
+        id: deploy
+        uses: cloudflare/wrangler-action@v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --minify
+
+      - name: Print website URL
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: echo $DEPLOYMENT_URL


### PR DESCRIPTION
Deploy the site to production on merge to main (or manual dispatch) via `wrangler deploy`. This is the only workflow that shifts live traffic; PR previews use preview.yaml (`wrangler versions upload`) and never reach prod.