### PR TITLE
Doc updates for v0.10.0-rc1

### DIFF
--- a/src/app/docs/kagent/concepts/agents/page.mdx
+++ b/src/app/docs/kagent/concepts/agents/page.mdx
@@ -267,6 +267,45 @@ spec:
 
 For more benchmarks and details, see the [Go vs Python runtime blog post](/blog/go-vs-python-runtime).
 
+## Deployment configuration
+
+The `spec.declarative.deployment` stanza controls how the agent's Kubernetes Deployment is configured.
+
+### Environment variables
+
+Use `env` to set individual environment variables, or `envFrom` to bulk-inject all keys from a ConfigMap or Secret.
+
+```yaml
+spec:
+  declarative:
+    deployment:
+      env:
+        - name: LOG_LEVEL
+          value: debug
+      envFrom:
+        - configMapRef:
+            name: my-agent-config
+        - secretRef:
+            name: my-agent-secrets
+```
+
+### Deployment annotations
+
+Use `deploymentAnnotations` to add annotations to the Deployment object itself. This field is distinct from the `annotations` field, which targets pod template metadata only.
+
+```yaml
+spec:
+  declarative:
+    deployment:
+      deploymentAnnotations:
+        argocd.argoproj.io/sync-wave: "5"
+        notifications.argoproj.io/subscribe.on-degraded.slack: my-channel
+      annotations:
+        prometheus.io/scrape: "true"   # pod template only
+```
+
+`deploymentAnnotations` is useful for GitOps tooling such as Argo CD sync waves and Flux annotations, which key off Deployment-level metadata rather than pod metadata.
+
 ## Memory
 
 Your agents can save and retrieve relevant context across conversations using vector similarity search. When you enable memory on an agent, it receives three additional tools (`save_memory`, `load_memory`, `prefetch_memory`) and automatically extracts key information every 5th user message.

--- a/src/app/docs/kagent/concepts/agents/page.mdx
+++ b/src/app/docs/kagent/concepts/agents/page.mdx
@@ -269,7 +269,7 @@ For more benchmarks and details, see the [Go vs Python runtime blog post](/blog/
 
 ## Deployment configuration
 
-The `spec.declarative.deployment` stanza controls how the agent's Kubernetes Deployment is configured.
+Control how the agent's Kubernetes Deployment is configured in the `spec.declarative.deployment` stanza.
 
 ### Environment variables
 

--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -411,6 +411,16 @@ extraObjects:
             key: anthropic-api-key
 ```
 
+### Disable the default ModelConfig
+
+By default, kagent creates a `ModelConfig` resource and associated Kubernetes Secret for the provider that you set with `providers.default`. To skip this and manage `ModelConfig` resources entirely outside the Helm chart, set `providers` to null:
+
+```yaml
+providers: null
+```
+
+When `providers` is null (or omitted), neither the `ModelConfig` nor its Secret are created. Use this setting when you apply `ModelConfig` resources through GitOps, a separate Helm chart, or another external process.
+
 ### Private registry and image mirroring
 
 If your cluster cannot pull from `ghcr.io` directly, such as in air-gapped environments, corporate proxies, or mandatory image scanning, you can mirror the kagent images to an internal registry and configure the chart to pull from this registry.

--- a/src/app/docs/kagent/introduction/installation/page.mdx
+++ b/src/app/docs/kagent/introduction/installation/page.mdx
@@ -419,7 +419,7 @@ By default, kagent creates a `ModelConfig` resource and associated Kubernetes Se
 providers: null
 ```
 
-When `providers` is null (or omitted), neither the `ModelConfig` nor its Secret are created. Use this setting when you apply `ModelConfig` resources through GitOps, a separate Helm chart, or another external process.
+When `providers` is null (or omitted), kagent does not create the `ModelConfig` or its Secret. Use this setting when you apply `ModelConfig` resources through GitOps, a separate Helm chart, or another external process.
 
 ### Private registry and image mirroring
 

--- a/src/app/docs/kagent/resources/release-notes/page.mdx
+++ b/src/app/docs/kagent/resources/release-notes/page.mdx
@@ -388,7 +388,7 @@ For details and usage examples, see [Run migrations out-of-band](/docs/kagent/op
 
 ## maxOutputTokens for Gemini and Vertex AI
 
-The `maxOutputTokens` field is now wired for the native Gemini and Vertex AI providers. Previously, this field was declared on `GeminiVertexAIConfig` but never applied, and `GeminiConfig` had no such field at all.
+The `maxOutputTokens` field is now wired for the native Gemini and Vertex AI providers. Previously, this field was declared on `GeminiVertexAIConfig` but never applied, and `GeminiConfig` did not define this field at all.
 
 ```yaml
 spec:
@@ -409,6 +409,8 @@ spec:
 ```
 
 A per-request value set by the agent always takes precedence over the model-level default.
+
+For more information, see [Gemini](/docs/kagent/supported-providers/gemini#max-output-tokens) and [Vertex AI](/docs/kagent/supported-providers/google-vertexai).
 
 ## AWS Bedrock Guardrails
 
@@ -432,11 +434,13 @@ spec:
 | `version` | The guardrail version to apply. Required when the `guardrail` block is present. |
 | `trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
 
-On the streaming path, guardrail interventions are applied before content is returned to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so the agent loop continues.
+Guardrail interventions apply before content returns to the caller so that blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, allowing the agent loop to continue.
+
+For more information, see [Amazon Bedrock — Bedrock Guardrails](/docs/kagent/supported-providers/amazon-bedrock#bedrock-guardrails).
 
 ## envFrom for agent deployments
 
-You can now bulk-inject environment variables from ConfigMaps and Secrets into agent pods using the `envFrom` field on the agent deployment spec. This complements the existing `env` field, which requires enumerating individual keys.
+You can now bulk-inject environment variables from ConfigMaps and Secrets into agent pods using the `envFrom` field on the agent deployment spec. This field complements the existing `env` field, which requires enumerating individual keys.
 
 ```yaml
 apiVersion: kagent.dev/v1alpha2
@@ -451,15 +455,19 @@ spec:
             name: my-agent-secrets
 ```
 
+For more information, see [Agents — Deployment configuration](/docs/kagent/concepts/agents#deployment-configuration).
+
 ## Disable default ModelConfig
 
-Set `providers: null` in your Helm values to suppress the default `ModelConfig` and its associated `Secret` from being created. This is useful when you manage `ModelConfig` resources outside the kagent Helm chart.
+To suppress the default `ModelConfig` and its associated `Secret` from being created, set `providers: null` in your Helm values. This setting is useful when you manage `ModelConfig` resources outside of the kagent Helm chart.
 
 ```yaml
 providers: null
 ```
 
-When `providers` is unset or null, neither the `modelconfig` nor the `modelconfig-secret` templates are rendered. Existing installs that supply `providers` are unaffected.
+When `providers` is unset or null, neither the `modelconfig` nor the `modelconfig-secret` templates are rendered. Existing installs that define `providers` are unaffected.
+
+For more information, see [Disable the default ModelConfig](/docs/kagent/introduction/installation#disable-the-default-modelconfig).
 
 ## Additional changes in v0.10
 
@@ -494,7 +502,7 @@ When `providers` is unset or null, neither the `modelconfig` nor the `modelconfi
 * **Azure OpenAI API key env var name**: The `AZURE_OPENAI_API_KEY` environment variable name is now used consistently throughout the codebase, fixing providers that were reading a mismatched key name.
 * **OpenTelemetry double-instrumentation fix**: The OpenAI client is no longer double-instrumented on the Go ADK runtime, preventing duplicate spans in OTel traces when using OpenAI with the Go runtime.
 * **Configurable Bedrock read/connect timeout**: New `bedrock.readTimeout` and `bedrock.connectTimeout` fields on `ModelConfig` replace the ~60s botocore default that caused `ReadTimeoutError` on long completions. Both values are in seconds and are optional.
-* **RFC 8707 resource and audience for STS token exchange**: The Go and Python ADK token-propagation plugins now read `KAGENT_STS_RESOURCE` and `KAGENT_STS_AUDIENCE` environment variables to scope issued STS tokens to a specific backend. Backwards compatible — existing deployments are unaffected when neither variable is set.
+* **RFC 8707 resource and audience for STS token exchange**: The Go and Python ADK token-propagation plugins now read `KAGENT_STS_RESOURCE` and `KAGENT_STS_AUDIENCE` environment variables to scope issued STS tokens to a specific backend. Backwards compatible so that existing deployments are unaffected when neither variable is set.
 
 **Agent Substrate**
 
@@ -521,7 +529,7 @@ When `providers` is unset or null, neither the `modelconfig` nor the `modelconfi
 * **UI rendering optimization**: Redundant background fetches in the chat interface are reduced, improving rendering performance for long sessions.
 * **ADK token refresh loop resilience**: Exceptions during token reads in the Python ADK no longer kill the background refresh goroutine. Failed reads are logged and the loop continues on the next cycle instead of silently stopping.
 * **ACP shim teardown deadlock fix**: Fixed a deadlock where `terminate()` could hang indefinitely when a WebSocket client stalled, blocking the stdout reader goroutine on a full channel and preventing the shim from shutting down.
-* **ADK session state with `num_recent_events`**: Fixed a bug where `session.state` was built from only the last N events when `num_recent_events` was set, silently dropping state deltas from older events. Full event history is now always used to compute state; `num_recent_events` only trims the returned events list.
+* **ADK session state with `num_recent_events`**: Fixed a bug where `session.state` was built from only the last `n` events when `num_recent_events` was set, silently dropping state deltas from older events. Full event history is now always used to compute state; `num_recent_events` only trims the returned events list.
 
 # v0.9
 

--- a/src/app/docs/kagent/resources/release-notes/page.mdx
+++ b/src/app/docs/kagent/resources/release-notes/page.mdx
@@ -28,6 +28,8 @@ Review this summary of significant changes from kagent version 0.9 to v0.10.
 
 * [Go ADK is now the default runtime](#go-adk-is-now-the-default-runtime): New declarative agents use the Go ADK by default.
 * [A2A AgentCard metadata](#a2a-agentcard-metadata): New optional fields on the Agent spec for enriching the A2A AgentCard.
+* [maxOutputTokens for Gemini and Vertex AI](#maxoutputtokens-for-gemini-and-vertex-ai): New `maxOutputTokens` field on Gemini and Vertex AI providers for capping model output length.
+* [AWS Bedrock Guardrails](#aws-bedrock-guardrails): Native guardrail support for the Bedrock provider, enabling content filtering, topic denial, and PII redaction.
 
 **Helm & configuration**
 
@@ -43,6 +45,8 @@ Review this summary of significant changes from kagent version 0.9 to v0.10.
 * [extraObjects](#extraobjects): New `extraObjects` Helm value for deploying arbitrary Kubernetes manifests in the same chart lifecycle as kagent.
 * [Deployment annotations](#deployment-annotations): New `controller.annotations` and `ui.annotations` Helm values for annotating the controller and UI Deployment resources.
 * [nodeSelector for agent Helm charts](#nodeselector-for-agent-helm-charts): New `nodeSelector` value in every bundled agent Helm chart for pinning agent pods to specific node pools.
+* [envFrom for agent deployments](#envfrom-for-agent-deployments): New `envFrom` field on the agent deployment spec for bulk-injecting environment variables from ConfigMaps and Secrets.
+* [Disable default ModelConfig](#disable-default-modelconfig): Set `providers: null` to suppress the Helm-generated default `ModelConfig` and `Secret`.
 
 **Agent Substrate**
 
@@ -382,6 +386,81 @@ A new `database.postgres.skipMigrations` Helm value (default: `false`) prevents 
 
 For details and usage examples, see [Run migrations out-of-band](/docs/kagent/operations/upgrade#run-migrations-out-of-band).
 
+## maxOutputTokens for Gemini and Vertex AI
+
+The `maxOutputTokens` field is now wired for the native Gemini and Vertex AI providers. Previously, this field was declared on `GeminiVertexAIConfig` but never applied, and `GeminiConfig` had no such field at all.
+
+```yaml
+spec:
+  provider: Gemini
+  model: gemini-2.5-pro
+  gemini:
+    maxOutputTokens: 8192
+```
+
+```yaml
+spec:
+  provider: GeminiVertexAI
+  model: gemini-2.5-pro
+  geminiVertexAI:
+    project: my-project
+    location: us-central1
+    maxOutputTokens: 8192
+```
+
+A per-request value set by the agent always takes precedence over the model-level default.
+
+## AWS Bedrock Guardrails
+
+You can now apply native [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) directly from `ModelConfig`. The controller passes the guardrail configuration to the Bedrock Converse and ConverseStream APIs, enabling content filtering, topic denial, and PII redaction without an external proxy.
+
+```yaml
+spec:
+  provider: Bedrock
+  model: us.anthropic.claude-sonnet-4-20250514-v1:0
+  bedrock:
+    region: us-east-1
+    guardrail:
+      identifier: "abc123def456"
+      version: "1"
+      trace: "enabled"
+```
+
+| Field | Description |
+|---|---|
+| `identifier` | The guardrail ID or ARN. Required when the `guardrail` block is present. |
+| `version` | The guardrail version to apply. Required when the `guardrail` block is present. |
+| `trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
+
+On the streaming path, guardrail interventions are applied before content is returned to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so the agent loop continues.
+
+## envFrom for agent deployments
+
+You can now bulk-inject environment variables from ConfigMaps and Secrets into agent pods using the `envFrom` field on the agent deployment spec. This complements the existing `env` field, which requires enumerating individual keys.
+
+```yaml
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+spec:
+  declarative:
+    deployment:
+      envFrom:
+        - configMapRef:
+            name: my-agent-config
+        - secretRef:
+            name: my-agent-secrets
+```
+
+## Disable default ModelConfig
+
+Set `providers: null` in your Helm values to suppress the default `ModelConfig` and its associated `Secret` from being created. This is useful when you manage `ModelConfig` resources outside the kagent Helm chart.
+
+```yaml
+providers: null
+```
+
+When `providers` is unset or null, neither the `modelconfig` nor the `modelconfig-secret` templates are rendered. Existing installs that supply `providers` are unaffected.
+
 ## Additional changes in v0.10
 
 **Security**
@@ -399,6 +478,7 @@ For details and usage examples, see [Run migrations out-of-band](/docs/kagent/op
 * **`nodeSelector` and `tolerations` for `kagent-tools` subchart**: The `kagent-tools` bundled subchart now accepts `nodeSelector` and `tolerations` values, so tools pods can be placed on specific nodes or tolerate taints.
 * **oauth2-proxy subchart updated to ~10.7.0**: The bundled oauth2-proxy dependency is bumped to the 10.7.x chart series.
 * **Custom annotations on the default ModelConfig**: A new per-provider `annotations` map under `providers.<provider>.annotations` is applied to the Helm-generated default ModelConfig. Useful for downstream tooling or UI extensions that key off resource annotations.
+* **`deploymentAnnotations` for agent deployments**: New `deploymentAnnotations` field on the agent deployment spec sets annotations on the Deployment object itself. The existing `annotations` field targets pod template metadata only. Useful for GitOps tooling such as Argo CD sync waves, Flux, and Kyverno policies that key off Deployment-level annotations.
 
 **Agent runtimes and providers**
 
@@ -413,6 +493,8 @@ For details and usage examples, see [Run migrations out-of-band](/docs/kagent/op
 * **Azure OpenAI secretKeyRef fix**: Fixed an issue where an empty `secretKeyRef` was generated for Azure OpenAI model configurations that do not use a Kubernetes secret for credentials.
 * **Azure OpenAI API key env var name**: The `AZURE_OPENAI_API_KEY` environment variable name is now used consistently throughout the codebase, fixing providers that were reading a mismatched key name.
 * **OpenTelemetry double-instrumentation fix**: The OpenAI client is no longer double-instrumented on the Go ADK runtime, preventing duplicate spans in OTel traces when using OpenAI with the Go runtime.
+* **Configurable Bedrock read/connect timeout**: New `bedrock.readTimeout` and `bedrock.connectTimeout` fields on `ModelConfig` replace the ~60s botocore default that caused `ReadTimeoutError` on long completions. Both values are in seconds and are optional.
+* **RFC 8707 resource and audience for STS token exchange**: The Go and Python ADK token-propagation plugins now read `KAGENT_STS_RESOURCE` and `KAGENT_STS_AUDIENCE` environment variables to scope issued STS tokens to a specific backend. Backwards compatible — existing deployments are unaffected when neither variable is set.
 
 **Agent Substrate**
 
@@ -437,6 +519,9 @@ For details and usage examples, see [Run migrations out-of-band](/docs/kagent/op
 * **UI tool call grouping**: Tool calls in the chat interface are now visually grouped, making it easier to follow multi-step agent reasoning.
 * **Model config name editing fix**: Fixed an issue where the model name field could not be edited on the model configuration form in the UI.
 * **UI rendering optimization**: Redundant background fetches in the chat interface are reduced, improving rendering performance for long sessions.
+* **ADK token refresh loop resilience**: Exceptions during token reads in the Python ADK no longer kill the background refresh goroutine. Failed reads are logged and the loop continues on the next cycle instead of silently stopping.
+* **ACP shim teardown deadlock fix**: Fixed a deadlock where `terminate()` could hang indefinitely when a WebSocket client stalled, blocking the stdout reader goroutine on a full channel and preventing the shim from shutting down.
+* **ADK session state with `num_recent_events`**: Fixed a bug where `session.state` was built from only the last N events when `num_recent_events` was set, silently dropping state deltas from older events. Full event history is now always used to compute state; `num_recent_events` only trims the returned events list.
 
 # v0.9
 

--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -108,7 +108,7 @@ If you want to use one shared ServiceAccount for multiple agents, you can also s
 
 ## Bedrock Guardrails
 
-You can apply [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) directly from the native Bedrock `ModelConfig` to enable content filtering, topic denial, and PII redaction. The guardrail is applied on every request to the Converse and ConverseStream APIs.
+You can apply [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) directly from the native Bedrock `ModelConfig` to enable content filtering, topic denial, and PII redaction. The guardrail applies on every request to the Converse and ConverseStream APIs.
 
 ```yaml
 spec:
@@ -128,11 +128,11 @@ spec:
 | `bedrock.guardrail.version` | The guardrail version to apply. Required when the `guardrail` block is present. |
 | `bedrock.guardrail.trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
 
-Guardrail interventions are applied before content returns to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so that the agent loop continues.
+Guardrail interventions apply before content returns to the caller so that blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, enabling the agent loop to continue.
 
 ## Request timeouts
 
-By default, the Bedrock client uses botocore's ~60 second read timeout, which can cause `ReadTimeoutError` on long completions. Use `bedrock.readTimeout` and `bedrock.connectTimeout` to override these values.
+By default, the Bedrock client uses botocore's ~60 second read timeout, which can cause `ReadTimeoutError` on long completions. To override these values, use `bedrock.readTimeout` and `bedrock.connectTimeout`.
 
 ```yaml
 spec:

--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -128,11 +128,11 @@ spec:
 | `bedrock.guardrail.version` | The guardrail version to apply. Required when the `guardrail` block is present. |
 | `bedrock.guardrail.trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
 
-Guardrail interventions are applied before content is returned to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so the agent loop continues.
+Guardrail interventions are applied before content returns to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so that the agent loop continues.
 
 ## Request timeouts
 
-By default, the Bedrock client uses botocore's ~60-second read timeout, which can cause `ReadTimeoutError` on long completions. Use `bedrock.readTimeout` and `bedrock.connectTimeout` to override these values.
+By default, the Bedrock client uses botocore's ~60 second read timeout, which can cause `ReadTimeoutError` on long completions. Use `bedrock.readTimeout` and `bedrock.connectTimeout` to override these values.
 
 ```yaml
 spec:

--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -128,7 +128,7 @@ spec:
 | `bedrock.guardrail.version` | The guardrail version to apply. Required when the `guardrail` block is present. |
 | `bedrock.guardrail.trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
 
-Guardrail interventions apply before content returns to the caller so that blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, enabling the agent loop to continue.
+Guardrail interventions apply before content returns to the caller so that blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, allowing the agent loop to continue.
 
 ## Request timeouts
 

--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -106,6 +106,51 @@ spec:
 
 If you want to use one shared ServiceAccount for multiple agents, you can also set `controller.agentDeployment.serviceAccountName` in the [Helm chart configuration](/docs/kagent/resources/helm).
 
+## Bedrock Guardrails
+
+You can apply [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) directly from the native Bedrock `ModelConfig` to enable content filtering, topic denial, and PII redaction. The guardrail is applied on every request to the Converse and ConverseStream APIs.
+
+```yaml
+spec:
+  provider: Bedrock
+  model: us.anthropic.claude-sonnet-4-20250514-v1:0
+  bedrock:
+    region: us-east-1
+    guardrail:
+      identifier: "abc123def456"
+      version: "1"
+      trace: "enabled"
+```
+
+| Field | Description |
+|---|---|
+| `bedrock.guardrail.identifier` | The guardrail ID or ARN. Required when the `guardrail` block is present. |
+| `bedrock.guardrail.version` | The guardrail version to apply. Required when the `guardrail` block is present. |
+| `bedrock.guardrail.trace` | Trace mode: `disabled` (default), `enabled`, or `enabled_full`. |
+
+Guardrail interventions are applied before content is returned to the caller, so blocked content does not leak to the stream. Interventions surface in the response content rather than as hard errors, so the agent loop continues.
+
+## Request timeouts
+
+By default, the Bedrock client uses botocore's ~60-second read timeout, which can cause `ReadTimeoutError` on long completions. Use `bedrock.readTimeout` and `bedrock.connectTimeout` to override these values.
+
+```yaml
+spec:
+  provider: Bedrock
+  model: us.anthropic.claude-sonnet-4-20250514-v1:0
+  bedrock:
+    region: us-east-1
+    readTimeout: 1800
+    connectTimeout: 30
+```
+
+| Field | Description |
+|---|---|
+| `bedrock.readTimeout` | Maximum seconds to wait for a response chunk. Minimum: 1. |
+| `bedrock.connectTimeout` | Maximum seconds to wait for the initial connection. Minimum: 1. Optional. |
+
+Both fields are optional. When neither is set, botocore defaults apply and existing behavior is unchanged.
+
 ## Option 2: OpenAI-compatible API
 
 You can also use Bedrock models via the [OpenAI Chat Completions API](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html). This option is useful when you need compatibility with the OpenAI API format or when using Bedrock's inference profiles.

--- a/src/app/docs/kagent/supported-providers/gemini/page.mdx
+++ b/src/app/docs/kagent/supported-providers/gemini/page.mdx
@@ -47,3 +47,17 @@ spec:
 4. Apply the above resource to the cluster.
 
 Once the resource is applied, you can select the model from the Model dropdown in the UI when creating or updating agents.
+
+## Max output tokens
+
+Use `gemini.maxOutputTokens` to cap the number of tokens the model can generate in a single response.
+
+```yaml
+spec:
+  provider: Gemini
+  model: gemini-2.5-pro
+  gemini:
+    maxOutputTokens: 8192
+```
+
+A per-request value set by the agent always takes precedence over this model-level default.

--- a/src/app/docs/kagent/supported-providers/gemini/page.mdx
+++ b/src/app/docs/kagent/supported-providers/gemini/page.mdx
@@ -50,7 +50,7 @@ Once the resource is applied, you can select the model from the Model dropdown i
 
 ## Max output tokens
 
-Use `gemini.maxOutputTokens` to cap the number of tokens the model can generate in a single response.
+Use `gemini.maxOutputTokens` to cap the number of tokens that the model can generate in a single response.
 
 ```yaml
 spec:


### PR DESCRIPTION
Adds docs for rc1 of the 0.10.0 branch.

Merging into the `v0.10.0-docs` branch, which will be held until v0.10.0 is cut.