### PR TITLE
Fixed Docs being bigger than other top nav options

### DIFF
--- a/docs-site/assets/css/custom.css
+++ b/docs-site/assets/css/custom.css
@@ -22,11 +22,11 @@
     border-bottom-color: #374151;
 }
 
-/* Theme-toggle icon visibility — explicit fallback for the Tailwind v4
-   hx:group-data-[theme=*]:hidden variant.  The v4 rule uses :is()/:where()
+/* -toggle icon visibility — explicit fallback for the Tailwind v4
+   hx:group-data-[=*]:hidden variant.  The v4 rule uses :is()/:where()
    which can lose the battle against Tailwind v3's svg{display:block} preflight
    when both pipelines run.  This direct descendant selector with !important
-   guarantees only the current-theme icon renders. */
+   guarantees only the current- icon renders. */
 .hx\:group[data-theme="light"]  .hx\:group-data-\[theme\=light\]\:hidden,
 .hx\:group[data-theme="dark"]   .hx\:group-data-\[theme\=dark\]\:hidden,
 .hx\:group[data-theme="system"] .hx\:group-data-\[theme\=system\]\:hidden {
@@ -450,10 +450,7 @@ h6 {
    Hextra renders the Docs item as a <button class="hextra-nav-menu-toggle">
    instead of an <a>, since it has child entries. Browsers don't apply the
    inherited hx:text-sm sizing to <button> the same way they do to <a>, so
-   Docs renders larger than its sibling nav links. docs-theme-extras ships
-   an equivalent fix, but only for the .dropdown > button/a markup pattern
-   used by kgateway/agentgateway-oss' custom navbar, not Hextra's native
-   .hextra-nav-menu-toggle markup used here, so it doesn't reach this case. */
+   Docs renders larger than its sibling nav links. */
 .hextra-nav-menu-toggle {
   font-family: inherit;
   font-size: 0.875rem; /* match hx:text-sm on sibling nav links */

--- a/docs-site/assets/css/custom.css
+++ b/docs-site/assets/css/custom.css
@@ -22,11 +22,11 @@
     border-bottom-color: #374151;
 }
 
-/* -toggle icon visibility — explicit fallback for the Tailwind v4
-   hx:group-data-[=*]:hidden variant.  The v4 rule uses :is()/:where()
+/* Theme-toggle icon visibility — explicit fallback for the Tailwind v4
+   hx:group-data-[theme=*]:hidden variant.  The v4 rule uses :is()/:where()
    which can lose the battle against Tailwind v3's svg{display:block} preflight
    when both pipelines run.  This direct descendant selector with !important
-   guarantees only the current- icon renders. */
+   guarantees only the current-theme icon renders. */
 .hx\:group[data-theme="light"]  .hx\:group-data-\[theme\=light\]\:hidden,
 .hx\:group[data-theme="dark"]   .hx\:group-data-\[theme\=dark\]\:hidden,
 .hx\:group[data-theme="system"] .hx\:group-data-\[theme\=system\]\:hidden {

--- a/docs-site/assets/css/custom.css
+++ b/docs-site/assets/css/custom.css
@@ -446,6 +446,21 @@ h6 {
   border-color: rgba(255, 255, 255, 0.1);
 }
 
+/* ── Top-nav dropdown toggle font size (Docs) ──────────────────────────
+   Hextra renders the Docs item as a <button class="hextra-nav-menu-toggle">
+   instead of an <a>, since it has child entries. Browsers don't apply the
+   inherited hx:text-sm sizing to <button> the same way they do to <a>, so
+   Docs renders larger than its sibling nav links. docs-theme-extras ships
+   an equivalent fix, but only for the .dropdown > button/a markup pattern
+   used by kgateway/agentgateway-oss' custom navbar, not Hextra's native
+   .hextra-nav-menu-toggle markup used here, so it doesn't reach this case. */
+.hextra-nav-menu-toggle {
+  font-family: inherit;
+  font-size: 0.875rem; /* match hx:text-sm on sibling nav links */
+  font-weight: 400;
+  line-height: 1.25rem;
+}
+
 /* Dropdown item spacing lives here, NOT in hx: utility classes: ad-hoc hx:
    spacing values (gap-3, px-4, py-2.5, …) that Hextra core doesn't already use
    are not generated in this Tailwind build, so they silently no-op. */


### PR DESCRIPTION
<img width="758" height="60" alt="Screenshot 2026-08-06 at 9 28 31 AM" src="https://github.com/user-attachments/assets/a034f78d-4762-40ae-9efb-4c2822a0d602" />
