### PR TITLE
Fix broken links from link-checker report

### DIFF
--- a/src/app/docs/kagent/concepts/agent-substrate/page.mdx
+++ b/src/app/docs/kagent/concepts/agent-substrate/page.mdx
@@ -73,7 +73,7 @@ An `AgentHarness` always runs on Agent Substrate; `spec.substrate` is required. 
 - `snapshotsConfig` — configures where actor memory snapshots are stored. Defaults to `gs://ate-snapshots/<namespace>/<agentharnessname>` when unset.
 - `workloadImage` — overrides the default OpenClaw or Hermes sandbox image used in the generated ActorTemplate.
 
-kagent talks to the harness over the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) so you can chat with it from the kagent UI. See the [Agent Harness concept page](/docs/kagent/concepts/agent-harness) for details.
+kagent talks to the harness over the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/introduction) so you can chat with it from the kagent UI. See the [Agent Harness concept page](/docs/kagent/concepts/agent-harness) for details.
 
 See the [API reference](/docs/kagent/resources/api-ref) for the full `AgentHarnessSubstrateSpec` schema.
 

--- a/src/app/docs/kagent/concepts/agents/page.mdx
+++ b/src/app/docs/kagent/concepts/agents/page.mdx
@@ -193,7 +193,7 @@ These skills contain instructions, scripts, and resources that are loaded from c
 
 Container-based skills are actual, callable capabilities—not just descriptions of capabilities.
 
-kagent's skills are similar to [Claude's Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview), but with a key advantage: you can use kagent's skills with any LLM provider, not just Anthropic Claude. This means your agents can use skills with OpenAI, Google Vertex AI, Azure OpenAI, Ollama, and any other LLM provider that kagent supports.
+kagent's skills are similar to [Claude's Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), but with a key advantage: you can use kagent's skills with any LLM provider, not just Anthropic Claude. This means your agents can use skills with OpenAI, Google Vertex AI, Azure OpenAI, Ollama, and any other LLM provider that kagent supports.
 
 ### Git-based skills
 

--- a/src/app/docs/kagent/concepts/architecture/page.mdx
+++ b/src/app/docs/kagent/concepts/architecture/page.mdx
@@ -30,16 +30,16 @@ In the future, we envision more features for the controller, such as:
 
 The kagent engine is the core component of kagent. It runs the agent's conversation loop and supports two runtimes:
 
-- **Python ADK** (default) — Built on top of the [Google ADK](https://google.github.io/adk-docs/) framework. Supports Google ADK-native features and integrations with CrewAI, LangGraph, and OpenAI frameworks.
+- **Python ADK** (default) — Built on top of the [Google ADK](https://adk.dev/) framework. Supports Google ADK-native features and integrations with CrewAI, LangGraph, and OpenAI frameworks.
 - **Go ADK** — A native Go implementation that provides faster startup (~2 seconds vs ~15 seconds) and lower resource consumption.
 
 Select the runtime by setting the `runtime` field in the agent spec (e.g., `runtime: go`). Both runtimes support MCP tools, HITL, and agent memory. For more details, see [Agents](/docs/kagent/concepts/agents#runtime).
 
 For more information on the Google ADK framework:
 
-- [Agents](https://google.github.io/adk-docs/agents/)
-- [Tools](https://google.github.io/adk-docs/tools/)
-- [Context](https://google.github.io/adk-docs/context/)
+- [Agents](https://adk.dev/agents/)
+- [Tools](https://adk.dev/tools/)
+- [Context](https://adk.dev/context/)
 
 ## CLI
 

--- a/src/app/docs/kagent/concepts/tools/page.mdx
+++ b/src/app/docs/kagent/concepts/tools/page.mdx
@@ -79,7 +79,7 @@ tools:
 
 ## MCP Tools
 
-MCP stands for [Model Context Protocol](https://modelcontextprotocol.io/introduction). It is a protocol, originally created by Anthropic, which is meant as a flexible way to provide tools and other information to Agents. In the year or so since its inception, it has begun to gain traction and more and more tools are adopting it. The [servers](https://github.com/modelcontextprotocol/servers) repository has a list of MCP servers that you can use immediately with kagent! Of course there are more than just the ones listed there, so we also support bringing in your own MCP servers.
+MCP stands for [Model Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro). It is a protocol, originally created by Anthropic, which is meant as a flexible way to provide tools and other information to Agents. In the year or so since its inception, it has begun to gain traction and more and more tools are adopting it. The [servers](https://github.com/modelcontextprotocol/servers) repository has a list of MCP servers that you can use immediately with kagent! Of course there are more than just the ones listed there, so we also support bringing in your own MCP servers.
 
 **Note:** Double check any community servers before running them in your environment.
 

--- a/src/app/docs/kagent/examples/a2a-agents/page.mdx
+++ b/src/app/docs/kagent/examples/a2a-agents/page.mdx
@@ -87,7 +87,7 @@ The A2A endpoint is exposed on the port `8083` of the kagent controller service.
    curl localhost:8083/api/a2a/kagent/k8s-a2a-agent/.well-known/agent.json
    ```
 
-   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a.guide/protocol/agent-card.html).
+   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a-protocol.org/latest/topics/key-concepts/).
 
    ```json
    {

--- a/src/app/docs/kagent/examples/a2a-byo/page.mdx
+++ b/src/app/docs/kagent/examples/a2a-byo/page.mdx
@@ -146,7 +146,7 @@ The A2A endpoint is exposed on the port `8083` of the kagent controller service.
    curl localhost:8083/api/a2a/kagent/basic-agent/.well-known/agent.json
    ```
 
-   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a.guide/protocol/agent-card.html).
+   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a-protocol.org/latest/topics/key-concepts/).
 
    ```json
    {

--- a/src/app/docs/kagent/examples/crewai-byo/page.mdx
+++ b/src/app/docs/kagent/examples/crewai-byo/page.mdx
@@ -12,7 +12,7 @@ export const metadata = {
 
 # Bringing your own CrewAI agent to kagent
 
-Bring your own custom agents. This example uses [CrewAI](https://www.crewai.com/), but you can also try out the [ADK guide](/docs/kagent/examples/a2a-byo/) or [LangGraph guide](/docs/kagent/examples/langchain-byo/). Such frameworks give you more control over the agent behavior and are well-suited for complex workflows and integration with external systems and APIs.
+Bring your own custom agents. This example uses [CrewAI](https://crewai.com/), but you can also try out the [ADK guide](/docs/kagent/examples/a2a-byo/) or [LangGraph guide](/docs/kagent/examples/langchain-byo/). Such frameworks give you more control over the agent behavior and are well-suited for complex workflows and integration with external systems and APIs.
 
 Unlike declarative agents that are defined by kagent resources with components such as system instructions, models, and tools written inline, these BYO agents give you full control over agent logic. If you have your own agent, no need to decompose its functions into separate kagent resources. kagent can invoke your agent directly through the A2A protocol.
 
@@ -129,7 +129,7 @@ The A2A endpoint is exposed on the port `8083` of the kagent controller service.
    curl localhost:8083/api/a2a/kagent/research-crew/.well-known/agent.json
    ```
 
-   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a.guide/protocol/agent-card.html).
+   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a-protocol.org/latest/topics/key-concepts/).
 
    ```json
    {

--- a/src/app/docs/kagent/examples/human-in-the-loop/page.mdx
+++ b/src/app/docs/kagent/examples/human-in-the-loop/page.mdx
@@ -30,7 +30,7 @@ Make sure you have these installed before starting:
 
 | Tool | Install Link |
 |------|-------------|
-| Docker | [get-docker](https://docs.docker.com/get-docker/) |
+| Docker | [get-docker](https://docs.docker.com/get-started/get-docker/) |
 | Kind | [quick-start](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
 | kubectl | [install-tools](https://kubernetes.io/docs/tasks/tools/) |
 | Helm | [install](https://helm.sh/docs/intro/install/) |

--- a/src/app/docs/kagent/examples/langchain-byo/page.mdx
+++ b/src/app/docs/kagent/examples/langchain-byo/page.mdx
@@ -20,7 +20,7 @@ Install kagent by following the [quick start](/docs/kagent/getting-started/quick
 
 ## Building a LangGraph agent
 
-The following example builds a simple LangGraph agent from the [kagent code repository](https://github.com/kagent-dev/kagent). The sample app is built with [LangGraph SDK](https://docs.langchain.com/langgraph-platform/sdk) and performs a currency exchange lookup task. It uses Google's Gemini model as the underlying LLM provider.
+The following example builds a simple LangGraph agent from the [kagent code repository](https://github.com/kagent-dev/kagent). The sample app is built with [LangGraph SDK](https://docs.langchain.com/langsmith/reference) and performs a currency exchange lookup task. It uses Google's Gemini model as the underlying LLM provider.
 
 1. Clone the kagent code repository.
 
@@ -103,7 +103,7 @@ The A2A endpoint is exposed on the port `8083` of the kagent controller service.
    curl localhost:8083/api/a2a/kagent/langgraph-agent/.well-known/agent.json
    ```
 
-   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a.guide/protocol/agent-card.html).
+   Example output: This JSON object describes the agent as per the [A2A protocol](https://a2a-protocol.org/latest/topics/key-concepts/).
 
    ```json
    {

--- a/src/app/docs/kagent/examples/slack-a2a/page.mdx
+++ b/src/app/docs/kagent/examples/slack-a2a/page.mdx
@@ -27,13 +27,13 @@ This guide demonstrates how to achieve exactly that. We will explore a two-way i
 1.  **Invoking kagent from Slack:** Learn how to set up a Slack bot that uses kagent's A2A (Agent-to-Agent) protocol to interact with a kagent agent, allowing you to run commands or ask questions about your cluster directly from Slack.
 2.  **Sending messages from kagent to Slack:** Discover how to configure a kagent agent to use an MCP (Model Context Protocol) server to send messages and notifications to specific Slack channels.
 
-To follow along, you'll first need to create a Slack App. We'll cover the necessary steps below, but you can also refer to the official [Slack documentation](https://api.slack.com/quickstart).
+To follow along, you'll first need to create a Slack App. We'll cover the necessary steps below, but you can also refer to the official [Slack documentation](https://docs.slack.dev/quickstart/).
 
 ## Creating a Slack App
 
 You will need a Slack workspace and sufficient permissions to create and install Slack apps. Assuming you have that, you can head over to https://api.slack.com/apps and follow the instructions below. 
 
->Note that these instructions might change, so make sure you check out the latest instructions on the [Slack website](https://api.slack.com/quickstart).
+>Note that these instructions might change, so make sure you check out the latest instructions on the [Slack website](https://docs.slack.dev/quickstart/).
 
 1. From the Your Apps page click the "Create an app" button.
 
@@ -93,12 +93,12 @@ Lastly we'll add a slash command that will allow us to invoke the bot directly u
 
 ## Writing a Slack bot
 
-Armed with two tokens, we can now go and write some code! We'll be using Bolt for Python, but you can also use Bolt for other languages. Start by cloning the [A2A Slack template](https://github.com/kagent-dev/a2a-slack-template.git).
+Armed with two tokens, we can now go and write some code! We'll be using Bolt for Python, but you can also use Bolt for other languages. Start by cloning the [A2A Slack template](https://github.com/kagent-dev/a2a-slack-template).
 
 1. Clone the repository:
 
 ```shell
-git clone https://github.com/kagent-dev/a2a-slack-template.git
+git clone https://github.com/kagent-dev/a2a-slack-template
 cd a2a-slack-template
 ```
 

--- a/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
+++ b/src/app/docs/kagent/introduction/what-is-kagent/page.mdx
@@ -53,7 +53,7 @@ Everything works with a single `helm install`. No add-ons, no extra databases, n
 
 ## Enterprise distributions
 
-Check out [Solo Enterprise for kagent](https://www.solo.io/products/kagent-enterprise), a comprehensive agent management interface for creating, validating, debugging, deploying, and monitoring AI agents across federated Kubernetes clusters. Solo Enterprise for kagent adds enterprise-grade capabilities on top of the kagent open source project, including advanced management features, observability tools, and multicluster federation support.
+Check out [Solo Enterprise for kagent](https://www.solo.io/products/kagent), a comprehensive agent management interface for creating, validating, debugging, deploying, and monitoring AI agents across federated Kubernetes clusters. Solo Enterprise for kagent adds enterprise-grade capabilities on top of the kagent open source project, including advanced management features, observability tools, and multicluster federation support.
 
 ## Getting Started
 

--- a/src/app/docs/kagent/resources/api-ref/page.mdx
+++ b/src/app/docs/kagent/resources/api-ref/page.mdx
@@ -848,7 +848,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `endpoint` _string_ | Endpoint is the Foundry or Azure AI Services account endpoint<br />(e.g., https://my-account.cognitiveservices.azure.com/).<br />Mutually exclusive with EndpointFrom. |  |  |
+| `endpoint` _string_ | Endpoint is the Foundry or Azure AI Services account endpoint<br />(e.g., `https://my-account.cognitiveservices.azure.com/`).<br />Mutually exclusive with EndpointFrom. |  |  |
 | `endpointFrom` _[ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#configmapkeyselector-v1-core)_ | EndpointFrom resolves the Foundry endpoint from a ConfigMap key, such as<br />one written by Azure Service Operator. Mutually exclusive with Endpoint.<br /><br />The selector's optional flag only controls how a missing key is handled: when<br />set to true, the missing key is ignored while reading the ConfigMap, but a<br />Foundry endpoint must always be supplied, so an unresolved endpointFrom still<br />leaves the model unusable and the agent fails to start. |  |  |
 | `deployment` _string_ | Deployment is the Foundry model deployment name. |  |  |
 | `apiVersion` _string_ | APIVersion is the Foundry OpenAI-compatible data-plane API version. | 2024-10-21 |  |

--- a/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
+++ b/src/app/docs/kagent/supported-providers/amazon-bedrock/page.mdx
@@ -62,7 +62,7 @@ If you are using access keys instead of an IAM role, add `apiKeySecret: bedrock-
 | Setting | Description |
 | --- | --- |
 | `provider` | Set to `Bedrock` for the native provider. |
-| `model` | The Bedrock model ID. Use the format from the [AWS Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html) (for example, `us.anthropic.claude-sonnet-4-20250514-v1:0`). |
+| `model` | The Bedrock model ID. Use the format from the [AWS Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) (for example, `us.anthropic.claude-sonnet-4-20250514-v1:0`). |
 | `apiKeySecret` | Optional. Set this when using a Kubernetes secret that contains `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Omit it when the agent uses the pod's AWS credential chain, such as an IAM role attached to the ServiceAccount. |
 | `bedrock.region` | The AWS region where the Bedrock model is available (for example, `us-east-1`). |
 

--- a/src/app/docs/kagent/supported-providers/google-vertexai/page.mdx
+++ b/src/app/docs/kagent/supported-providers/google-vertexai/page.mdx
@@ -14,7 +14,7 @@ export const metadata = {
 
 Google Vertex AI is supported for Gemini and Anthropic models.
 
-1. Create the [Google Application Default Credentials file](https://cloud.google.com/docs/authentication/provide-credentials-adc) and store it in a Kubernetes Secret. If your credentials are in a different location, update the filepath.
+1. Create the [Google Application Default Credentials file](https://docs.cloud.google.com/docs/authentication/provide-credentials-adc) and store it in a Kubernetes Secret. If your credentials are in a different location, update the filepath.
 
 ```shell
 kubectl create secret generic kagent-google-creds -n kagent --from-file=~/.config/gcloud/application_default_credentials.json

--- a/src/app/docs/kmcp/develop/fastmcp-python/page.mdx
+++ b/src/app/docs/kmcp/develop/fastmcp-python/page.mdx
@@ -12,7 +12,7 @@ export const metadata = {
 
 # FastMCP Python
 
-[FastMCP Python](https://github.com/jlowin/fastmcp) is a lightweight, high-performance Python framework that implements the Model Context Protocol (MCP). With KMCP, you can quickly create an MCP project that uses the FastMCP framework with a sample MCP server and `echo` tool that you can use as a boilerplate to develop your own tools. 
+[FastMCP Python](https://github.com/PrefectHQ/fastmcp) is a lightweight, high-performance Python framework that implements the Model Context Protocol (MCP). With KMCP, you can quickly create an MCP project that uses the FastMCP framework with a sample MCP server and `echo` tool that you can use as a boilerplate to develop your own tools. 
 
 ## Prerequisites
 

--- a/src/app/docs/kmcp/introduction/page.mdx
+++ b/src/app/docs/kmcp/introduction/page.mdx
@@ -10,7 +10,7 @@ kmcp is a comprehensive platform to accelerate the local development of Model Co
 
 ## About MCP
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol developed by Anthropic that standardizes how Large Language Model (LLM) applications connect to various external data sources and tools. Without MCP, you need to implement custom integrations for each tool that your LLM application needs to access. However, this approach is hard to maintain and can cause issues when you want to scale your environment. With MCP, you can significantly speed up, simplify, and standardize these types of integrations. An MCP server exposes external data sources and tools so that LLM applications can access them. 
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) is an open protocol developed by Anthropic that standardizes how Large Language Model (LLM) applications connect to various external data sources and tools. Without MCP, you need to implement custom integrations for each tool that your LLM application needs to access. However, this approach is hard to maintain and can cause issues when you want to scale your environment. With MCP, you can significantly speed up, simplify, and standardize these types of integrations. An MCP server exposes external data sources and tools so that LLM applications can access them. 
 
 ## What is kmcp?
 

--- a/src/blogContent/crewai-byo-agent.mdx
+++ b/src/blogContent/crewai-byo-agent.mdx
@@ -9,7 +9,7 @@ export const metadata = {
 
 # From CrewAI to KAgent: Deploying Your Custom AI Agents
 
-If you've been working with [CrewAI](https://www.crewai.com/) and love how it lets you orchestrate multiple AI agents for complex tasks, you might be wondering how to take those agents from your local development environment to a production-ready deployment.
+If you've been working with [CrewAI](https://crewai.com/) and love how it lets you orchestrate multiple AI agents for complex tasks, you might be wondering how to take those agents from your local development environment to a production-ready deployment.
 That's where KAgent's Bring-Your-Own (BYO) agent feature comes in. With our latest support for CrewAI BYO agents, this process is now seamless and straightforward.
 
 In this post, we'll walk through transforming your existing CrewAI crew into a KAgent BYO agent. We'll assume you already have a working CrewAI agent and focus on deployment steps.


### PR DESCRIPTION


**Fix broken links from link-checker report #457**

Fixes 25 broken or outdated links across 17 files, flagged by the automated link checker in report #457. 
Changes include:

- Updated redirected/moved doc URLs (MCP protocol docs, Google ADK docs to adk.dev, Slack API docs, AWS Bedrock, Google Cloud auth, Claude docs)
- Fixed A2A protocol spec links (a2a.guide to a2a-protocol.org)
- Corrected GitHub org for FastMCP Python (jlowin to PrefectHQ)
- Removed unnecessary `.git` suffix and `www.` prefixes from a few links
- Wrapped a bare example URL in backticks in the API reference table

**Not addressed** (out of scope, needs follow-up):
- `servereverything.dev/mcp`: unclear if the 406 is a false positive or a genuinely broken URL
- 4 `kubernetes.io`/`git.k8s.io` anchor warnings: outside this repo's control

All new links verified to resolve (200 OK). No changes to Markdown link syntax or file structure elsewhere in the affected pages.